### PR TITLE
Changing the version references 3.2 to 3.3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 * Running
   ```
-  scons target=<debug|release|release_debug> arch=<arch> simulator=<no|yes> plugin=<plugin_name> version=<3.2|4.0>
+  scons target=<debug|release|release_debug> arch=<arch> simulator=<no|yes> plugin=<plugin_name> version=<3.3|4.0>
   ```
   will generate `.a` static library for chosen target.  
   Do note, that Godot's default `debug` export template is compiled with `release_debug` target.

--- a/SConstruct
+++ b/SConstruct
@@ -25,7 +25,7 @@ opts.Add(BoolVariable('simulator', "Compilation platform", 'no'))
 opts.Add(BoolVariable('use_llvm', "Use the LLVM / Clang compiler", 'no'))
 opts.Add(PathVariable('target_path', 'The path where the lib is installed.', 'bin/'))
 opts.Add(EnumVariable('plugin', 'Plugin to build', '', ['', 'apn', 'arkit', 'camera', 'icloud', 'gamecenter', 'inappstore']))
-opts.Add(EnumVariable('version', 'Godot version to target', '', ['', '3.2', '4.0']))
+opts.Add(EnumVariable('version', 'Godot version to target', '', ['', '3.3', '4.0']))
 
 # Updates the environment with the option variables.
 opts.Update(env)


### PR DESCRIPTION
Since the new iOS plugin support will only be present in 3.3 onwards.

https://godotengine.org/article/versioning-change-godot-3x
https://godotengine.org/article/release-candidate-godot-3-3-rc-6