### PR TITLE
PhotoPicker plugin implementation

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -24,7 +24,7 @@ opts.Add(EnumVariable('arch', "Compilation Architecture", '', ['', 'arm64', 'arm
 opts.Add(BoolVariable('simulator', "Compilation platform", 'no'))
 opts.Add(BoolVariable('use_llvm', "Use the LLVM / Clang compiler", 'no'))
 opts.Add(PathVariable('target_path', 'The path where the lib is installed.', 'bin/'))
-opts.Add(EnumVariable('plugin', 'Plugin to build', '', ['', 'apn', 'arkit', 'camera', 'icloud', 'gamecenter', 'inappstore']))
+opts.Add(EnumVariable('plugin', 'Plugin to build', '', ['', 'apn', 'arkit', 'camera', 'icloud', 'gamecenter', 'inappstore', 'photo_picker']))
 opts.Add(EnumVariable('version', 'Godot version to target', '', ['', '3.3', '4.0']))
 
 # Updates the environment with the option variables.

--- a/plugins/photo_picker/README.md
+++ b/plugins/photo_picker/README.md
@@ -1,0 +1,73 @@
+# Godot PhotoPicker plugin
+
+Example:
+
+```
+var _picker = null
+
+func _image_picked(image):
+	var texture = ImageTexture.new()
+	texture.create_from_image(image)
+	icon.texture = texture
+
+func _permission_updated(target, status):
+	match (target):
+		apns.PERMISSION_TARGET_PHOTO_LIBRARY:
+			print("photo library")
+		apns.PERMISSION_TARGET_CAMERA:
+			print("camera")
+	
+	match (status):
+		apns.PERMISSION_STATUS_UNKNOWN:
+			print("unknown")
+		apns.PERMISSION_STATUS_ALLOWED:
+			print("allowed")
+		apns.PERMISSION_STATUS_DENIED:
+			print("denied")
+
+func _on_Button_button_down():
+	apns.present(apns.SOURCE_SAVED_PHOTOS_ALBUM);
+	apns.present(apns.SOURCE_CAMERA_REAR);
+	apns.present(apns.SOURCE_CAMERA_FRONT);
+
+	print(apns.permission_status(apns.PERMISSION_TARGET_CAMERA))
+	print(apns.permission_status(apns.PERMISSION_TARGET_PHOTO_LIBRARY))
+
+	apns.request_permission(apns.PERMISSION_TARGET_CAMERA)
+	apns.request_permission(apns.PERMISSION_TARGET_PHOTO_LIBRARY)
+
+...
+
+func _ready():
+	if Engine.has_singleton("PhotoPicker"):
+		_picker = Engine.get_singleton("PhotoPicker")
+		_picker.connect("image_picked", self, "_image_picked")
+		_picker.connect("permission_updated", self, "_permission_updated")
+		print("registering photo picker")
+	else:
+		print("no photo picker")
+```
+
+## Enum
+
+Type: `PhotoPickerSourceType`
+Values: `SOURCE_PHOTO_LIBRARY`, `SOURCE_CAMERA_FRONT`, `SOURCE_CAMERA_REAR`, `SOURCE_SAVED_PHOTOS_ALBUM`
+
+Type: `PhotoPickerPermissionTarget`
+Values: `PERMISSION_TARGET_PHOTO_LIBRARY`, `PERMISSION_TARGET_CAMERA`
+
+Type: `PhotoPickerPermissionStatus`
+Values: `PERMISSION_STATUS_UNKNOWN`, `PERMISSION_STATUS_ALLOWED`, `PERMISSION_STATUS_DENIED`
+
+## Methods
+
+`permission_status(PhotoPickerPermissionTarget target): PhotoPickerPermissionStatus` - Returns a permissions status for specific photo picker target.
+`request_permission(PhotoPickerPermissionTarget target)` - Performs a permission request for photo picker permission target if needed.
+`present(PhotoPickerSourceType source)` - Presents a photo picker with specific source type that allows to select an image or take a picture from camera.
+
+## Properties
+
+## Signals
+
+`image_picked(Ref<Image> image)` - Called whenever user selects an image from a library or takes a photo.
+`permission_updated(PhotoPickerPermissionTarget image)` - Called when user changes permission status after `request_permission` is called.

--- a/plugins/photo_picker/photo_picker.gdip
+++ b/plugins/photo_picker/photo_picker.gdip
@@ -1,0 +1,19 @@
+[config]
+name="PhotoPicker"
+binary="photo_picker.xcframework"
+
+initialization="godot_photopicker_init"
+deinitialization="godot_photopicker_deinit"
+
+[dependencies]
+linked=[]
+embedded=[]
+system=[]
+
+capabilities=[]
+
+files=[]
+
+[plist]
+NSPhotoLibraryUsageDescription:string_input="Photo Library usage description"
+NSCameraUsageDescription:string_input="Camera usage description"

--- a/plugins/photo_picker/photo_picker.h
+++ b/plugins/photo_picker/photo_picker.h
@@ -1,0 +1,88 @@
+/*************************************************************************/
+/*  photo_picker.h                                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef PHOTO_PICKER_H
+#define PHOTO_PICKER_H
+
+#include "core/version.h"
+
+#include "core/image.h"
+#include "core/object.h"
+
+#ifdef __OBJC__
+@class GodotPhotoPicker;
+#else
+typedef void GodotPhotoPicker;
+#endif
+
+class PhotoPicker : public Object {
+	GDCLASS(PhotoPicker, Object);
+
+	static void _bind_methods();
+
+	GodotPhotoPicker *godot_photo_picker;
+
+public:
+	enum PhotoPickerSourceType {
+		SOURCE_PHOTO_LIBRARY = 1 << 0,
+		SOURCE_CAMERA_FRONT = 1 << 1,
+		SOURCE_CAMERA_REAR = 1 << 2,
+		SOURCE_SAVED_PHOTOS_ALBUM = 1 << 3,
+	};
+
+	enum PhotoPickerPermissionTarget {
+		PERMISSION_TARGET_PHOTO_LIBRARY = 1 << 0,
+		PERMISSION_TARGET_CAMERA = 1 << 1,
+	};
+
+	enum PhotoPickerPermissionStatus {
+		PERMISSION_STATUS_UNKNOWN = 1 << 0,
+		PERMISSION_STATUS_ALLOWED = 1 << 1,
+		PERMISSION_STATUS_DENIED = 1 << 2,
+	};
+
+	static PhotoPicker *get_singleton();
+
+	void present(PhotoPickerSourceType source);
+	void request_permission(PhotoPickerPermissionTarget target);
+	PhotoPickerPermissionStatus permission_status(PhotoPickerPermissionTarget target);
+
+	void select_image(Ref<Image> image);
+	void update_permission_status(PhotoPicker::PhotoPickerPermissionTarget target, PhotoPicker::PhotoPickerPermissionStatus status);
+
+	PhotoPicker();
+	~PhotoPicker();
+};
+
+VARIANT_ENUM_CAST(PhotoPicker::PhotoPickerSourceType)
+VARIANT_ENUM_CAST(PhotoPicker::PhotoPickerPermissionTarget)
+VARIANT_ENUM_CAST(PhotoPicker::PhotoPickerPermissionStatus)
+
+#endif

--- a/plugins/photo_picker/photo_picker.mm
+++ b/plugins/photo_picker/photo_picker.mm
@@ -1,0 +1,354 @@
+/*************************************************************************/
+/*  photo_picker.cpp                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "photo_picker.h"
+
+#import <Foundation/Foundation.h>
+#import <Photos/Photos.h>
+
+#import "platform/iphone/app_delegate.h"
+#import "platform/iphone/view_controller.h"
+
+PhotoPicker *instance = NULL;
+
+@interface GodotPhotoPicker : NSObject <UINavigationControllerDelegate, UIImagePickerControllerDelegate>
+
+@end
+
+@implementation GodotPhotoPicker
+
+- (void)presentUsingSourceType:(PhotoPicker::PhotoPickerSourceType)source {
+	_weakify(self);
+
+	dispatch_async(dispatch_get_main_queue(), ^{
+		_strongify(self);
+
+		UIViewController *root_controller = [[UIApplication sharedApplication] delegate].window.rootViewController;
+
+		if (!root_controller) {
+			return;
+		}
+
+		UIImagePickerController *picker = [[UIImagePickerController alloc] init];
+		picker.delegate = self;
+
+		switch (source) {
+			case PhotoPicker::SOURCE_SAVED_PHOTOS_ALBUM:
+				picker.sourceType = UIImagePickerControllerSourceTypeSavedPhotosAlbum;
+				break;
+			case PhotoPicker::SOURCE_PHOTO_LIBRARY:
+				picker.sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
+				break;
+			case PhotoPicker::SOURCE_CAMERA_REAR:
+				picker.sourceType = UIImagePickerControllerSourceTypeCamera;
+				picker.cameraDevice = UIImagePickerControllerCameraDeviceRear;
+				break;
+			case PhotoPicker::SOURCE_CAMERA_FRONT:
+				picker.sourceType = UIImagePickerControllerSourceTypeCamera;
+				picker.cameraDevice = UIImagePickerControllerCameraDeviceFront;
+				break;
+		}
+
+		[root_controller presentViewController:picker animated:YES completion:nil];
+	});
+}
+
+- (void)requestPermissionForTarget:(PhotoPicker::PhotoPickerPermissionTarget)target {
+	switch (target) {
+		case PhotoPicker::PERMISSION_TARGET_PHOTO_LIBRARY:
+			switch ([PHPhotoLibrary authorizationStatus]) {
+				case PHAuthorizationStatusLimited:
+				case PHAuthorizationStatusAuthorized:
+				case PHAuthorizationStatusDenied:
+				case PHAuthorizationStatusRestricted:
+					break;
+				case PHAuthorizationStatusNotDetermined:
+					[PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus authorizationStatus) {
+						PhotoPicker::PhotoPickerPermissionStatus status = PhotoPicker::PERMISSION_STATUS_DENIED;
+
+						switch (authorizationStatus) {
+							case PHAuthorizationStatusLimited:
+							case PHAuthorizationStatusAuthorized:
+								status = PhotoPicker::PERMISSION_STATUS_ALLOWED;
+								break;
+							default:
+								break;
+						}
+						PhotoPicker::get_singleton()->update_permission_status(target, status);
+					}];
+					break;
+			}
+			break;
+		case PhotoPicker::PERMISSION_TARGET_CAMERA:
+			switch ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo]) {
+				case AVAuthorizationStatusAuthorized:
+				case AVAuthorizationStatusDenied:
+				case AVAuthorizationStatusRestricted:
+					break;
+				case AVAuthorizationStatusNotDetermined:
+					[AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo
+											 completionHandler:^(BOOL isAllowed) {
+												 dispatch_async(dispatch_get_main_queue(), ^{
+													 PhotoPicker::PhotoPickerPermissionStatus status = isAllowed ? PhotoPicker::PERMISSION_STATUS_ALLOWED : PhotoPicker::PERMISSION_STATUS_DENIED;
+													 PhotoPicker::get_singleton()->update_permission_status(target, status);
+												 });
+											 }];
+					break;
+			}
+			break;
+	}
+}
+
+- (PhotoPicker::PhotoPickerPermissionStatus)permissionStatusForTarget:(PhotoPicker::PhotoPickerPermissionTarget)target {
+	PhotoPicker::PhotoPickerPermissionStatus status = PhotoPicker::PERMISSION_STATUS_UNKNOWN;
+
+	switch (target) {
+		case PhotoPicker::PERMISSION_TARGET_PHOTO_LIBRARY:
+			switch ([PHPhotoLibrary authorizationStatus]) {
+				case PHAuthorizationStatusLimited:
+				case PHAuthorizationStatusAuthorized:
+					status = PhotoPicker::PERMISSION_STATUS_ALLOWED;
+					break;
+				case PHAuthorizationStatusDenied:
+				case PHAuthorizationStatusRestricted:
+					status = PhotoPicker::PERMISSION_STATUS_DENIED;
+					break;
+				case PHAuthorizationStatusNotDetermined:
+					status = PhotoPicker::PERMISSION_STATUS_UNKNOWN;
+					break;
+			}
+			break;
+		case PhotoPicker::PERMISSION_TARGET_CAMERA:
+			switch ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo]) {
+				case AVAuthorizationStatusAuthorized:
+					status = PhotoPicker::PERMISSION_STATUS_ALLOWED;
+					break;
+				case AVAuthorizationStatusDenied:
+				case AVAuthorizationStatusRestricted:
+					status = PhotoPicker::PERMISSION_STATUS_DENIED;
+					break;
+				case AVAuthorizationStatusNotDetermined:
+					status = PhotoPicker::PERMISSION_STATUS_UNKNOWN;
+					break;
+			}
+			break;
+	}
+
+	return status;
+}
+
+- (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker {
+	[picker dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary<UIImagePickerControllerInfoKey, id> *)info {
+	UIImage *image = info[UIImagePickerControllerOriginalImage];
+
+	if (image) {
+		CGImageRef cgImage = [[self class] newRGBA8CGImageFromUIImage:image];
+
+		if (cgImage) {
+			CGDataProviderRef provider = CGImageGetDataProvider(cgImage);
+			CFDataRef bmp = CGDataProviderCopyData(provider);
+			const unsigned char *data = CFDataGetBytePtr(bmp);
+			CFIndex length = CFDataGetLength(bmp);
+
+			if (data) {
+				Ref<Image> img;
+
+				PoolVector<uint8_t> img_data;
+				img_data.resize(length);
+				PoolVector<uint8_t>::Write w = img_data.write();
+				memcpy(w.ptr(), data, length);
+
+				img.instance();
+				img->create(image.size.width * image.scale, image.size.height * image.scale, 0, Image::FORMAT_RGBA8, img_data);
+
+				PhotoPicker::get_singleton()->select_image(img);
+			}
+
+			CFRelease(bmp);
+			CGImageRelease(cgImage);
+		}
+	}
+
+	[picker dismissViewControllerAnimated:YES completion:nil];
+}
+
++ (CGImageRef)newRGBA8CGImageFromUIImage:(UIImage *)image {
+	size_t bitsPerPixel = 32;
+	size_t bitsPerComponent = 8;
+	size_t bytesPerPixel = bitsPerPixel / bitsPerComponent;
+
+	size_t width = image.size.width;
+	size_t height = image.size.height;
+	UIImageOrientation orientation = image.imageOrientation;
+
+	size_t bytesPerRow = width * bytesPerPixel;
+
+	CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+
+	if (!colorSpace) {
+		NSLog(@"Error allocating color space RGB");
+		return NULL;
+	}
+
+	CGAffineTransform transform = CGAffineTransformIdentity;
+
+	switch (orientation) {
+		case UIImageOrientationDown:
+		case UIImageOrientationDownMirrored:
+			transform = CGAffineTransformTranslate(transform, width, height);
+			transform = CGAffineTransformRotate(transform, M_PI);
+			break;
+		case UIImageOrientationLeft:
+		case UIImageOrientationLeftMirrored:
+			transform = CGAffineTransformTranslate(transform, width, 0);
+			transform = CGAffineTransformRotate(transform, M_PI_2);
+			break;
+		case UIImageOrientationRight:
+		case UIImageOrientationRightMirrored:
+			transform = CGAffineTransformTranslate(transform, 0, height);
+			transform = CGAffineTransformRotate(transform, -M_PI_2);
+			break;
+		default:
+			break;
+	}
+
+	switch (orientation) {
+		case UIImageOrientationUpMirrored:
+		case UIImageOrientationDownMirrored:
+			transform = CGAffineTransformTranslate(transform, width, 0);
+			transform = CGAffineTransformScale(transform, -1, 1);
+			break;
+		case UIImageOrientationLeftMirrored:
+		case UIImageOrientationRightMirrored:
+			transform = CGAffineTransformTranslate(transform, height, 0);
+			transform = CGAffineTransformScale(transform, -1, 1);
+			break;
+		default:
+			break;
+	}
+
+	CGContextRef context = CGBitmapContextCreate(NULL,
+			width,
+			height,
+			bitsPerComponent,
+			bytesPerRow,
+			colorSpace,
+			kCGImageAlphaPremultipliedLast);
+
+	CGImageRef newCGImage = NULL;
+
+	if (!context) {
+		NSLog(@"Bitmap context not created");
+	} else {
+
+		CGContextConcatCTM(context, transform);
+
+		switch (orientation) {
+			case UIImageOrientationLeft:
+			case UIImageOrientationLeftMirrored:
+			case UIImageOrientationRight:
+			case UIImageOrientationRightMirrored:
+				CGContextDrawImage(context, CGRectMake(0, 0, height, width), [image CGImage]);
+				break;
+			default:
+				CGContextDrawImage(context, CGRectMake(0, 0, width, height), [image CGImage]);
+				break;
+		}
+
+		newCGImage = CGBitmapContextCreateImage(context);
+	}
+
+	CGColorSpaceRelease(colorSpace);
+	CGContextRelease(context);
+
+	return newCGImage;
+}
+
+@end
+
+PhotoPicker *PhotoPicker::get_singleton() {
+	return instance;
+}
+
+void PhotoPicker::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("present", "mode"), &PhotoPicker::present);
+	ClassDB::bind_method(D_METHOD("request_permission", "target"), &PhotoPicker::request_permission);
+	ClassDB::bind_method(D_METHOD("permission_status", "target"), &PhotoPicker::permission_status);
+
+	ADD_SIGNAL(MethodInfo("image_picked", PropertyInfo(Variant::OBJECT, "image")));
+	ADD_SIGNAL(MethodInfo("permission_updated", PropertyInfo(Variant::INT, "target"), PropertyInfo(Variant::INT, "status")));
+
+	BIND_ENUM_CONSTANT(SOURCE_PHOTO_LIBRARY);
+	BIND_ENUM_CONSTANT(SOURCE_CAMERA_FRONT);
+	BIND_ENUM_CONSTANT(SOURCE_CAMERA_REAR);
+	BIND_ENUM_CONSTANT(SOURCE_SAVED_PHOTOS_ALBUM);
+
+	BIND_ENUM_CONSTANT(PERMISSION_TARGET_PHOTO_LIBRARY);
+	BIND_ENUM_CONSTANT(PERMISSION_TARGET_CAMERA);
+
+	BIND_ENUM_CONSTANT(PERMISSION_STATUS_UNKNOWN);
+	BIND_ENUM_CONSTANT(PERMISSION_STATUS_ALLOWED);
+	BIND_ENUM_CONSTANT(PERMISSION_STATUS_DENIED);
+}
+
+void PhotoPicker::present(PhotoPickerSourceType source) {
+	[godot_photo_picker presentUsingSourceType:source];
+}
+
+void PhotoPicker::request_permission(PhotoPicker::PhotoPickerPermissionTarget target) {
+	[godot_photo_picker requestPermissionForTarget:target];
+}
+
+PhotoPicker::PhotoPickerPermissionStatus PhotoPicker::permission_status(PhotoPicker::PhotoPickerPermissionTarget target) {
+	return [godot_photo_picker permissionStatusForTarget:target];
+}
+
+void PhotoPicker::select_image(Ref<Image> image) {
+	emit_signal("image_picked", image);
+}
+
+void PhotoPicker::update_permission_status(PhotoPicker::PhotoPickerPermissionTarget target, PhotoPicker::PhotoPickerPermissionStatus status) {
+	emit_signal("permission_updated", target, status);
+}
+
+PhotoPicker::PhotoPicker() {
+	instance = this;
+
+	godot_photo_picker = [[GodotPhotoPicker alloc] init];
+}
+
+PhotoPicker::~PhotoPicker() {
+	instance = NULL;
+
+	godot_photo_picker = nil;
+}

--- a/plugins/photo_picker/photo_picker_module.cpp
+++ b/plugins/photo_picker/photo_picker_module.cpp
@@ -1,0 +1,49 @@
+/*************************************************************************/
+/*  photo_picker_module.cpp                                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "photo_picker_module.h"
+
+#include "core/engine.h"
+#include "core/version.h"
+
+#include "photo_picker.h"
+
+PhotoPicker *photo_picker;
+
+void godot_photopicker_init() {
+	photo_picker = memnew(PhotoPicker);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("PhotoPicker", photo_picker));
+}
+
+void godot_photopicker_deinit() {
+	if (photo_picker) {
+		memdelete(photo_picker);
+	}
+}

--- a/plugins/photo_picker/photo_picker_module.h
+++ b/plugins/photo_picker/photo_picker_module.h
@@ -1,0 +1,32 @@
+/*************************************************************************/
+/*  photo_picker_module.h                                                */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+void godot_photopicker_init();
+void godot_photopicker_deinit();

--- a/scripts/release_static_library.sh
+++ b/scripts/release_static_library.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GODOT_PLUGINS="gamecenter inappstore icloud camera arkit apn"
+GODOT_PLUGINS="gamecenter inappstore icloud camera arkit apn photo_picker"
 
 # Compile Plugin
 for lib in $GODOT_PLUGINS; do

--- a/scripts/release_xcframework.sh
+++ b/scripts/release_xcframework.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-GODOT_PLUGINS="gamecenter inappstore icloud camera arkit apn"
+GODOT_PLUGINS="gamecenter inappstore icloud camera arkit apn photo_picker"
 
 # Compile Plugin
 for lib in $GODOT_PLUGINS; do


### PR DESCRIPTION
Implementation of PhotoPicker plugin, which allows to use native `UIImagePickerController` to take a photo or select an image from library.

`gdip` uses new `string_input` plist type which allows to modify required key on export.