### PR TITLE
[WIP] Haptic engine plugin for enhance vibration

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -24,7 +24,7 @@ opts.Add(EnumVariable('arch', "Compilation Architecture", '', ['', 'arm64', 'arm
 opts.Add(BoolVariable('simulator', "Compilation platform", 'no'))
 opts.Add(BoolVariable('use_llvm', "Use the LLVM / Clang compiler", 'no'))
 opts.Add(PathVariable('target_path', 'The path where the lib is installed.', 'bin/'))
-opts.Add(EnumVariable('plugin', 'Plugin to build', '', ['', 'apn', 'arkit', 'camera', 'icloud', 'gamecenter', 'inappstore', 'photo_picker']))
+opts.Add(EnumVariable('plugin', 'Plugin to build', '', ['', 'apn', 'arkit', 'camera', 'icloud', 'gamecenter', 'haptic_engine', 'inappstore', 'photo_picker']))
 opts.Add(EnumVariable('version', 'Godot version to target', '', ['', '3.x', '4.0']))
 
 # Updates the environment with the option variables.

--- a/plugins/haptic_engine/haptic_engine.gdip
+++ b/plugins/haptic_engine/haptic_engine.gdip
@@ -1,0 +1,17 @@
+[config]
+name="HapticEngine"
+binary="haptic_engine.xcframework"
+
+initialization="haptic_engine_init"
+deinitialization="haptic_engine_deinit"
+
+[dependencies]
+linked=[]
+embedded=[]
+system=[]
+
+capabilities=[]
+
+files=[]
+
+[plist]

--- a/plugins/haptic_engine/haptic_engine.h
+++ b/plugins/haptic_engine/haptic_engine.h
@@ -1,3 +1,32 @@
+/*************************************************************************/
+/*  haptic_engine.h                                                      */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
 
 #ifndef HAPTIC_ENGINE_H
 #define HAPTIC_ENGINE_H
@@ -11,7 +40,6 @@
 #endif
 
 #import <CoreHaptics/CoreHaptics.h>
-// #import <Foundation/NSArray.h>
 
 class HapticEngine : public Object {
 	GDCLASS(HapticEngine, Object);

--- a/plugins/haptic_engine/haptic_engine.h
+++ b/plugins/haptic_engine/haptic_engine.h
@@ -1,0 +1,34 @@
+
+#ifndef HAPTIC_ENGINE_H
+#define HAPTIC_ENGINE_H
+
+#include "core/version.h"
+
+#if VERSION_MAJOR == 4
+#include "core/object/class_db.h"
+#else
+#include "core/object.h"
+#endif
+
+#import <CoreHaptics/CoreHaptics.h>
+// #import <Foundation/NSArray.h>
+
+class HapticEngine : public Object {
+	GDCLASS(HapticEngine, Object);
+
+	static HapticEngine *instance;
+	static void _bind_methods();
+
+private:
+	CHHapticEngine *haptic_engine API_AVAILABLE(ios(13)) = nullptr;
+
+public:
+	void vibrate(int duration_ms, float intensity, float sharpness);
+
+	static HapticEngine *get_singleton();
+
+	HapticEngine();
+	~HapticEngine();
+};
+
+#endif

--- a/plugins/haptic_engine/haptic_engine.mm
+++ b/plugins/haptic_engine/haptic_engine.mm
@@ -1,3 +1,32 @@
+/*************************************************************************/
+/*  haptic_engine.mm                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
 
 #include "haptic_engine.h"
 
@@ -8,10 +37,8 @@
 #endif
 
 #import <CoreHaptics/CoreHaptics.h>
-// #import <Foundation/NSArray.h>
 
 HapticEngine *HapticEngine::instance = NULL;
-// static CHHapticEngine *haptic_engine API_AVAILABLE(ios(13)) = nullptr;
 
 void HapticEngine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("vibrate"), &HapticEngine::vibrate);

--- a/plugins/haptic_engine/haptic_engine.mm
+++ b/plugins/haptic_engine/haptic_engine.mm
@@ -1,0 +1,99 @@
+
+#include "haptic_engine.h"
+
+#if VERSION_MAJOR == 4
+#import "platform/ios/app_delegate.h"
+#else
+#import "platform/iphone/app_delegate.h"
+#endif
+
+#import <CoreHaptics/CoreHaptics.h>
+// #import <Foundation/NSArray.h>
+
+HapticEngine *HapticEngine::instance = NULL;
+// static CHHapticEngine *haptic_engine API_AVAILABLE(ios(13)) = nullptr;
+
+void HapticEngine::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("vibrate"), &HapticEngine::vibrate);
+};
+
+void HapticEngine::vibrate(int duration_ms, float intensity, float sharpness) API_AVAILABLE(ios(13)) {
+	if (haptic_engine == nullptr) {
+		NSLog(@"Haptic engine not available");
+		return;
+	}
+
+	NSDictionary *hapticDict = @{
+		CHHapticPatternKeyPattern : @[
+			@{CHHapticPatternKeyEvent : @{
+				CHHapticPatternKeyEventType : CHHapticEventTypeHapticContinuous,
+				CHHapticPatternKeyTime : @(CHHapticTimeImmediate),
+				CHHapticPatternKeyEventDuration : @((float)duration_ms / 1000.f),
+				CHHapticPatternKeyEventParameters : @[
+					@{
+						CHHapticPatternKeyParameterID : CHHapticEventParameterIDHapticIntensity,
+						CHHapticPatternKeyParameterValue : @(intensity)
+					},
+					@{
+						CHHapticPatternKeyParameterID : CHHapticEventParameterIDHapticSharpness,
+						CHHapticPatternKeyParameterValue : @(sharpness)
+					}
+				]
+			},
+			},
+		],
+	};
+
+	NSError *error;
+	CHHapticPattern *pattern = [[CHHapticPattern alloc] initWithDictionary:hapticDict error:&error];
+	if (error) {
+		NSLog(@"Could not initialize haptic pattern: %@", error);
+		return;
+	}
+
+	[[haptic_engine createPlayerWithPattern:pattern error:&error] startAtTime:0 error:&error];
+	if (error) {
+		NSLog(@"Could not play haptic pattern: %@", error);
+		return;
+	}
+}
+
+HapticEngine *HapticEngine::get_singleton() {
+	return instance;
+}
+
+HapticEngine::HapticEngine() {
+	ERR_FAIL_COND(instance != NULL);
+	instance = this;
+
+	if (@available(iOS 13, *)) {
+		id<CHHapticDeviceCapability> capabilities = [CHHapticEngine capabilitiesForHardware];
+		if (!capabilities.supportsHaptics) {
+			NSLog(@"Hardware does not support haptics");
+			return;
+		}
+
+		NSError *error = nullptr;
+		haptic_engine = [[CHHapticEngine alloc] initAndReturnError:&error];
+		if (error) {
+			haptic_engine = nullptr;
+			NSLog(@"Could not initialize haptic engine: %@", error);
+		}
+
+		[haptic_engine setAutoShutdownEnabled:true];
+	} else {
+		NSLog(@"Haptic engine requires iOS 13 or older");
+	}
+};
+
+HapticEngine::~HapticEngine() {
+	if (@available(iOS 13, *)) {
+		if (haptic_engine) {
+			[haptic_engine stopWithCompletionHandler:^(NSError *error) {
+				if (error) {
+					NSLog(@"Could not stop haptic engine: %@", error);
+				}
+			}];
+		}
+	}
+}

--- a/plugins/haptic_engine/haptic_engine_module.h
+++ b/plugins/haptic_engine/haptic_engine_module.h
@@ -1,0 +1,10 @@
+//
+//  godot_plugin.h
+//  godot_plugin
+//
+//  Created by Sergey Minakov on 14.08.2020.
+//  Copyright © 2020 Godot. All rights reserved.
+//
+
+void haptic_engine_init();
+void haptic_engine_deinit();

--- a/plugins/haptic_engine/haptic_engine_module.h
+++ b/plugins/haptic_engine/haptic_engine_module.h
@@ -1,10 +1,32 @@
-//
-//  godot_plugin.h
-//  godot_plugin
-//
-//  Created by Sergey Minakov on 14.08.2020.
-//  Copyright © 2020 Godot. All rights reserved.
-//
+/*************************************************************************/
+/*  game_center_delegate.h                                               */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
 
 void haptic_engine_init();
 void haptic_engine_deinit();

--- a/plugins/haptic_engine/haptic_engine_module.mm
+++ b/plugins/haptic_engine/haptic_engine_module.mm
@@ -1,3 +1,32 @@
+/*************************************************************************/
+/*  haptic_engine_module.mm                                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
 
 #include "haptic_engine_module.h"
 

--- a/plugins/haptic_engine/haptic_engine_module.mm
+++ b/plugins/haptic_engine/haptic_engine_module.mm
@@ -1,0 +1,25 @@
+
+#include "haptic_engine_module.h"
+
+#include "core/version.h"
+
+#if VERSION_MAJOR == 4
+#include "core/config/engine.h"
+#else
+#include "core/engine.h"
+#endif
+
+#include "haptic_engine.h"
+
+HapticEngine *haptic_engine;
+
+void haptic_engine_init() {
+	haptic_engine = memnew(HapticEngine);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("HapticEngine", haptic_engine));
+}
+
+void haptic_engine_deinit() {
+	if (haptic_engine) {
+		memdelete(haptic_engine);
+	}
+}


### PR DESCRIPTION
The default [`Input.vibrate_handheld`](https://github.com/godotengine/godot/blob/61d2c855114c824f5ca27ded0a1fa71cc7b21134/platform/ios/ios.mm#L72) method is generic and don't support granular control over iOS's haptic engine, which support additional parameters like intensity and sharpness.

This allows you to trigger vibration with `.vibrate(duration, intensity, sharpness)`

There's also additional features like creating dynamic vibrations (Apple [doc](https://developer.apple.com/documentation/corehaptics/updating_continuous_and_transient_haptic_parameters_in_real_time?language=objc)) I plan to add here, but wanted to create this PR first and see if there's any interest.

TODOs

* add README
* add dynamic control