### PR TITLE
Add achievement rarity to GameCenter plugin

### DIFF
--- a/plugins/gamecenter/game_center.mm
+++ b/plugins/gamecenter/game_center.mm
@@ -204,6 +204,7 @@ void GameCenter::request_achievement_descriptions() {
 			GodotIntArray maximum_points;
 			Array hidden;
 			Array replayable;
+			GodotFloatArray rarity_percents;
 
 			for (NSUInteger i = 0; i < [descriptions count]; i++) {
 
@@ -226,6 +227,14 @@ void GameCenter::request_achievement_descriptions() {
 				hidden.push_back(description.hidden == YES);
 
 				replayable.push_back(description.replayable == YES);
+
+				NSNumber *number;
+				#ifdef __IPHONE_17_0
+				if (@available(iOS 17.0, *)) {
+					number = description.rarityPercent;
+				}
+				#endif
+				rarity_percents.push_back(number != NULL ? number.doubleValue : -1);
 			}
 
 			ret["names"] = names;
@@ -235,6 +244,7 @@ void GameCenter::request_achievement_descriptions() {
 			ret["maximum_points"] = maximum_points;
 			ret["hidden"] = hidden;
 			ret["replayable"] = replayable;
+			ret["rarity_percents"] = rarity_percents;
 
 		} else {
 			ret["result"] = "error";


### PR DESCRIPTION
#### Objective

Support the `rarityPercent` property that was added to `GKAchievementDescription` in iOS 17.0.

Doc: https://developer.apple.com/documentation/gamekit/gkachievementdescription/4273663-raritypercent

#### Changes

- Add `rarity_percents` to the `achievement_descriptions` event dictionary and wire the value from the newly introduced property,
- Fallback to `-1` if the iOS version is below 17.0 or if the achievement doesn't have a rarity percent value (i.e. `nil` is provided by GameKit).


#### Testing

Tested with Godot 3.5.0 and iOS 17, fetching achievements that have and do not have rarities.