### PR TITLE
Update ARKit for Godot 4.3

### DIFF
--- a/.github/workflows/ci_4_x.yml
+++ b/.github/workflows/ci_4_x.yml
@@ -33,7 +33,7 @@ jobs:
           ./scripts/release_xcframework.sh 4.0
           ls -l bin/release
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: plugins
           path: bin/release/*

--- a/.github/workflows/ci_4_x.yml
+++ b/.github/workflows/ci_4_x.yml
@@ -1,0 +1,41 @@
+name: Continuous integration 4.x
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build (macOS)
+    runs-on: "macos-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+          architecture: 'x64'
+
+      - name: Configuring Python
+        run: |
+          python -c "import sys; print(sys.version)"
+          python -m pip install scons
+          python --version
+          scons --version
+
+      - name: Generate Headers
+        run: |
+          ./scripts/generate_headers.sh 4.x || true
+
+      - name: Compile Plugins
+        run: |
+          ./scripts/release_xcframework.sh 4.x
+          ls -l bin/release
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: plugins
+          path: bin/release/*
+          retention-days: 4
+          if-no-files-found: error

--- a/.github/workflows/ci_4_x.yml
+++ b/.github/workflows/ci_4_x.yml
@@ -26,11 +26,11 @@ jobs:
 
       - name: Generate Headers
         run: |
-          ./scripts/generate_headers.sh 4.x || true
+          ./scripts/generate_headers.sh 4.0 || true
 
       - name: Compile Plugins
         run: |
-          ./scripts/release_xcframework.sh 4.x
+          ./scripts/release_xcframework.sh 4.0
           ls -l bin/release
 
       - uses: actions/upload-artifact@v2

--- a/plugins/arkit/arkit_anchor_mesh.h
+++ b/plugins/arkit/arkit_anchor_mesh.h
@@ -40,17 +40,17 @@
 
 class ARKitAnchorMesh : public XRPositionalTracker {
 	GDCLASS(ARKitAnchorMesh, XRPositionalTracker);
-    _THREAD_SAFE_CLASS_
+	_THREAD_SAFE_CLASS_
 
 private:
-    Ref<Mesh> mesh;
+	Ref<Mesh> mesh;
 
 protected:
 	static void _bind_methods();
 
 public:
-    void set_mesh(Ref<Mesh> mesh);
-    Ref<Mesh> get_mesh() const;
+	void set_mesh(Ref<Mesh> mesh);
+	Ref<Mesh> get_mesh() const;
 
 	ARKitAnchorMesh();
 	~ARKitAnchorMesh();

--- a/plugins/arkit/arkit_anchor_mesh.h
+++ b/plugins/arkit/arkit_anchor_mesh.h
@@ -31,6 +31,10 @@
 #ifndef ARKIT_ANCHOR_MESH_H
 #define ARKIT_ANCHOR_MESH_H
 
+#include "core/os/os.h"
+#include "core/version.h"
+#include "scene/resources/surface_tool.h"
+
 #include "servers/xr/xr_interface.h"
 #include "servers/xr/xr_positional_tracker.h"
 

--- a/plugins/arkit/arkit_anchor_mesh.h
+++ b/plugins/arkit/arkit_anchor_mesh.h
@@ -1,0 +1,55 @@
+/*************************************************************************/
+/*  arkit_interface.h                                                    */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef ARKIT_ANCHOR_MESH_H
+#define ARKIT_ANCHOR_MESH_H
+
+#include "servers/xr/xr_interface.h"
+#include "servers/xr/xr_positional_tracker.h"
+
+class ARKitAnchorMesh : public XRPositionalTracker {
+	GDCLASS(ARKitAnchorMesh, XRPositionalTracker);
+    _THREAD_SAFE_CLASS_
+
+private:
+    Ref<Mesh> mesh;
+
+protected:
+	static void _bind_methods();
+
+public:
+    void set_mesh(Ref<Mesh> mesh);
+    Ref<Mesh> get_mesh() const;
+
+	ARKitAnchorMesh();
+	~ARKitAnchorMesh();
+};
+
+#endif /* !ARKIT_ANCHOR_MESH_H */

--- a/plugins/arkit/arkit_anchor_mesh.mm
+++ b/plugins/arkit/arkit_anchor_mesh.mm
@@ -54,21 +54,21 @@
 #include "arkit_anchor_mesh.h"
 
 void ARKitAnchorMesh::set_mesh(Ref<Mesh> p_mesh) {
-    mesh = p_mesh;
+	mesh = p_mesh;
 }
 
 Ref<Mesh> ARKitAnchorMesh::get_mesh() const {
-    return mesh;
+	return mesh;
 }
 
 void ARKitAnchorMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_mesh", "mesh"), &ARKitAnchorMesh::set_mesh);
 	ClassDB::bind_method(D_METHOD("get_mesh"), &ARKitAnchorMesh::get_mesh);
-    ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "mesh", PROPERTY_HINT_RESOURCE_TYPE, "Mesh"), "set_mesh", "get_mesh");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "mesh", PROPERTY_HINT_RESOURCE_TYPE, "Mesh"), "set_mesh", "get_mesh");
 }
 
 ARKitAnchorMesh::ARKitAnchorMesh(){
-    mesh = NULL;
+	mesh = NULL;
 }
 
 ARKitAnchorMesh::~ARKitAnchorMesh(){

--- a/plugins/arkit/arkit_anchor_mesh.mm
+++ b/plugins/arkit/arkit_anchor_mesh.mm
@@ -1,0 +1,76 @@
+/*************************************************************************/
+/*  arkit_interface.h                                                    */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "core/os/os.h"
+#include "core/version.h"
+#include "scene/resources/surface_tool.h"
+
+#include "core/input/input.h"
+#include "servers/rendering/rendering_server_globals.h"
+
+#define GODOT_FOCUS_IN_NOTIFICATION DisplayServer::WINDOW_EVENT_FOCUS_IN
+#define GODOT_FOCUS_OUT_NOTIFICATION DisplayServer::WINDOW_EVENT_FOCUS_OUT
+
+#define GODOT_MAKE_THREAD_SAFE ;
+
+#define GODOT_AR_STATE_NOT_TRACKING XRInterface::XR_NOT_TRACKING
+#define GODOT_AR_STATE_NORMAL_TRACKING XRInterface::XR_NORMAL_TRACKING
+#define GODOT_AR_STATE_EXCESSIVE_MOTION XRInterface::XR_EXCESSIVE_MOTION
+#define GODOT_AR_STATE_INSUFFICIENT_FEATURES XRInterface::XR_INSUFFICIENT_FEATURES
+#define GODOT_AR_STATE_UNKNOWN_TRACKING XRInterface::XR_UNKNOWN_TRACKING
+
+#import <ARKit/ARKit.h>
+#import <UIKit/UIKit.h>
+
+#include <dlfcn.h>
+
+#include "arkit_anchor_mesh.h"
+
+void ARKitAnchorMesh::set_mesh(Ref<Mesh> p_mesh) {
+    mesh = p_mesh;
+}
+
+Ref<Mesh> ARKitAnchorMesh::get_mesh() const {
+    return mesh;
+}
+
+void ARKitAnchorMesh::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_mesh", "mesh"), &ARKitAnchorMesh::set_mesh);
+	ClassDB::bind_method(D_METHOD("get_mesh"), &ARKitAnchorMesh::get_mesh);
+    ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "mesh", PROPERTY_HINT_RESOURCE_TYPE, "Mesh"), "set_mesh", "get_mesh");
+}
+
+ARKitAnchorMesh::ARKitAnchorMesh(){
+    mesh = NULL;
+}
+
+ARKitAnchorMesh::~ARKitAnchorMesh(){
+
+}

--- a/plugins/arkit/arkit_interface.h
+++ b/plugins/arkit/arkit_interface.h
@@ -93,7 +93,7 @@ private:
 	GodotUInt8Vector img_data[2];
 
 #if VERSION_MAJOR == 4
-  XRInterface::TrackingStatus tracking_state;
+	XRInterface::TrackingStatus tracking_state;
 #endif
 
 	struct anchor_map {
@@ -135,27 +135,27 @@ public:
 	virtual bool is_initialized() const GODOT_ARKIT_OVERRIDE;
 	virtual bool initialize() GODOT_ARKIT_OVERRIDE;
 	virtual void uninitialize() GODOT_ARKIT_OVERRIDE;
-  virtual Dictionary get_system_info() GODOT_ARKIT_OVERRIDE;
+	virtual Dictionary get_system_info() GODOT_ARKIT_OVERRIDE;
+
+	/** input and output **/
+ 	virtual TrackingStatus get_tracking_status() const GODOT_ARKIT_OVERRIDE { return tracking_state; };
+	
+	/** specific to AR **/
+	virtual bool get_anchor_detection_is_enabled() const GODOT_ARKIT_OVERRIDE;
+	virtual void set_anchor_detection_is_enabled(bool p_enable) GODOT_ARKIT_OVERRIDE;
+	virtual int get_camera_feed_id() GODOT_ARKIT_OVERRIDE;
+
+	/** rendering and internal **/
+
+	virtual Transform3D get_camera_transform() GODOT_ARKIT_OVERRIDE;
+	virtual void process() GODOT_ARKIT_OVERRIDE;
 
 	virtual Size2 get_render_target_size() GODOT_ARKIT_OVERRIDE;
 	virtual uint32_t get_view_count() GODOT_ARKIT_OVERRIDE;
-  virtual Transform3D get_camera_transform() GODOT_ARKIT_OVERRIDE;
 	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) GODOT_ARKIT_OVERRIDE;
 	virtual Projection get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) GODOT_ARKIT_OVERRIDE;
-
-	virtual void process() GODOT_ARKIT_OVERRIDE;
-  virtual void pre_render(){} GODOT_ARKIT_OVERRIDE;
-	virtual bool pre_draw_viewport(RID p_render_target) GODOT_ARKIT_OVERRIDE;
+	
 	virtual Vector<BlitToScreen> post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) GODOT_ARKIT_OVERRIDE;
-	virtual void end_frame() GODOT_ARKIT_OVERRIDE;
-
-  virtual bool is_passthrough_supported() GODOT_ARKIT_OVERRIDE;
-	virtual bool is_passthrough_enabled() GODOT_ARKIT_OVERRIDE;
-	virtual bool start_passthrough() GODOT_ARKIT_OVERRIDE;
-	virtual void stop_passthrough() GODOT_ARKIT_OVERRIDE;
-
-	virtual Array get_supported_environment_blend_modes() GODOT_ARKIT_OVERRIDE;
-	virtual bool set_environment_blend_mode(EnvironmentBlendMode mode) GODOT_ARKIT_OVERRIDE;
 
 	// called by delegate (void * because C++ and Obj-C don't always mix, should really change all platform/ios/*.cpp files to .mm)
 	void _add_or_update_anchor(GodotARAnchor *p_anchor);

--- a/plugins/arkit/arkit_interface.h
+++ b/plugins/arkit/arkit_interface.h
@@ -84,6 +84,7 @@ private:
 	real_t ambient_intensity;
 	real_t ambient_color_temperature;
 
+	Ref<XRPositionalTracker> m_head;
 	Transform3D transform;
 	Projection projection;
 	float eye_height, z_near, z_far;

--- a/plugins/arkit/arkit_interface.h
+++ b/plugins/arkit/arkit_interface.h
@@ -83,6 +83,7 @@ private:
 	bool light_estimation_is_enabled;
 	real_t ambient_intensity;
 	real_t ambient_color_temperature;
+	real_t exposure_offset;
 
 	Ref<XRPositionalTracker> m_head;
 	Transform3D transform;
@@ -123,6 +124,7 @@ public:
 
 	real_t get_ambient_intensity() const;
 	real_t get_ambient_color_temperature() const;
+	real_t get_exposure_offset() const;
 
 	/* while Godot has its own raycast logic this takes ARKits camera into account and hits on any ARAnchor */
 	Array raycast(Vector2 p_screen_coord);

--- a/plugins/arkit/arkit_interface.h
+++ b/plugins/arkit/arkit_interface.h
@@ -125,20 +125,18 @@ public:
 	/* while Godot has its own raycast logic this takes ARKits camera into account and hits on any ARAnchor */
 	Array raycast(Vector2 p_screen_coord);
 
-	virtual void notification(int p_what) GODOT_ARKIT_OVERRIDE;
-
 	virtual StringName get_name() const GODOT_ARKIT_OVERRIDE;
-	virtual int get_capabilities() const GODOT_ARKIT_OVERRIDE;
+	virtual uint32_t get_capabilities() const GODOT_ARKIT_OVERRIDE;
 
 	virtual bool is_initialized() const GODOT_ARKIT_OVERRIDE;
 	virtual bool initialize() GODOT_ARKIT_OVERRIDE;
 	virtual void uninitialize() GODOT_ARKIT_OVERRIDE;
 
-	virtual Size2 get_render_targetsize() GODOT_ARKIT_OVERRIDE;
-	virtual bool is_stereo() GODOT_ARKIT_OVERRIDE;
-	virtual Transform3D get_transform_for_eye(GodotBaseARInterface::Eyes p_eye, const Transform3D &p_cam_transform) GODOT_ARKIT_OVERRIDE;
-	virtual Projection get_projection_for_eye(GodotBaseARInterface::Eyes p_eye, real_t p_aspect, real_t p_z_near, real_t p_z_far) GODOT_ARKIT_OVERRIDE;
-	virtual void commit_for_eye(GodotBaseARInterface::Eyes p_eye, RID p_render_target, const Rect2 &p_screen_rect) GODOT_ARKIT_OVERRIDE;
+	virtual Size2 get_render_target_size() GODOT_ARKIT_OVERRIDE;
+	virtual uint32_t get_view_count() GODOT_ARKIT_OVERRIDE;
+  virtual Transform3D get_camera_transform() GODOT_ARKIT_OVERRIDE;
+	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) GODOT_ARKIT_OVERRIDE;
+	virtual Projection get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) GODOT_ARKIT_OVERRIDE;
 
 	virtual void process() GODOT_ARKIT_OVERRIDE;
 

--- a/plugins/arkit/arkit_interface.h
+++ b/plugins/arkit/arkit_interface.h
@@ -75,6 +75,8 @@ typedef void GodotARAnchor;
 class ARKitInterface : public GodotBaseARInterface {
 	GDCLASS(ARKitInterface, GodotBaseARInterface);
 
+  static ARKitInterface *instance;
+
 private:
 	bool initialized;
 	bool session_was_started;
@@ -133,29 +135,11 @@ public:
 	virtual void uninitialize() GODOT_ARKIT_OVERRIDE;
   virtual Dictionary get_system_info() GODOT_ARKIT_OVERRIDE;
 
- 	virtual PackedStringArray get_suggested_tracker_names() const GODOT_ARKIT_OVERRIDE;
-	virtual PackedStringArray get_suggested_pose_names(const StringName &p_tracker_name) const GODOT_ARKIT_OVERRIDE;
-	virtual TrackingStatus get_tracking_status() const GODOT_ARKIT_OVERRIDE;
-	virtual void trigger_haptic_pulse(const String &p_action_name, const StringName &p_tracker_name, double p_frequency, double p_amplitude, double p_duration_sec, double p_delay_sec = 0) GODOT_ARKIT_OVERRIDE; /* trigger a haptic pulse */
-
-	virtual bool supports_play_area_mode(XRInterface::PlayAreaMode p_mode) GODOT_ARKIT_OVERRIDE;
-	virtual XRInterface::PlayAreaMode get_play_area_mode() const GODOT_ARKIT_OVERRIDE;
-	virtual bool set_play_area_mode(XRInterface::PlayAreaMode p_mode) GODOT_ARKIT_OVERRIDE;
-	virtual PackedVector3Array get_play_area() const GODOT_ARKIT_OVERRIDE;
-
-  virtual bool get_anchor_detection_is_enabled() const GODOT_ARKIT_OVERRIDE;
-	virtual void set_anchor_detection_is_enabled(bool p_enable) GODOT_ARKIT_OVERRIDE;
-	virtual int get_camera_feed_id() GODOT_ARKIT_OVERRIDE;
-
 	virtual Size2 get_render_target_size() GODOT_ARKIT_OVERRIDE;
 	virtual uint32_t get_view_count() GODOT_ARKIT_OVERRIDE;
   virtual Transform3D get_camera_transform() GODOT_ARKIT_OVERRIDE;
 	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) GODOT_ARKIT_OVERRIDE;
 	virtual Projection get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) GODOT_ARKIT_OVERRIDE;
-  virtual RID get_vrs_texture() GODOT_ARKIT_OVERRIDE;
-	virtual RID get_color_texture() GODOT_ARKIT_OVERRIDE;
-	virtual RID get_depth_texture() GODOT_ARKIT_OVERRIDE;
-	virtual RID get_velocity_texture() GODOT_ARKIT_OVERRIDE;
 
 	virtual void process() GODOT_ARKIT_OVERRIDE;
   virtual void pre_render(){} GODOT_ARKIT_OVERRIDE;

--- a/plugins/arkit/arkit_interface.h
+++ b/plugins/arkit/arkit_interface.h
@@ -36,9 +36,10 @@
 #if VERSION_MAJOR == 4
 #include "servers/xr/xr_interface.h"
 #include "servers/xr/xr_positional_tracker.h"
+#include "arkit_anchor_mesh.h"
 
 typedef XRInterface GodotBaseARInterface;
-typedef XRPositionalTracker GodotARTracker;
+typedef ARKitAnchorMesh GodotARTracker;
 
 typedef Vector<uint8_t> GodotUInt8Vector;
 

--- a/plugins/arkit/arkit_interface.h
+++ b/plugins/arkit/arkit_interface.h
@@ -115,11 +115,7 @@ protected:
 public:
 	void start_session();
 	void stop_session();
-
-	bool get_anchor_detection_is_enabled() const GODOT_ARKIT_OVERRIDE;
-	void set_anchor_detection_is_enabled(bool p_enable) GODOT_ARKIT_OVERRIDE;
-	virtual int get_camera_feed_id() GODOT_ARKIT_OVERRIDE;
-
+	
 	bool get_light_estimation_is_enabled() const;
 	void set_light_estimation_is_enabled(bool p_enable);
 

--- a/plugins/arkit/arkit_interface.h
+++ b/plugins/arkit/arkit_interface.h
@@ -83,8 +83,8 @@ private:
 	real_t ambient_intensity;
 	real_t ambient_color_temperature;
 
-	Transform transform;
-	CameraMatrix projection;
+	Transform3D transform;
+	Projection projection;
 	float eye_height, z_near, z_far;
 
 	Ref<CameraFeed> feed;
@@ -136,8 +136,8 @@ public:
 
 	virtual Size2 get_render_targetsize() GODOT_ARKIT_OVERRIDE;
 	virtual bool is_stereo() GODOT_ARKIT_OVERRIDE;
-	virtual Transform get_transform_for_eye(GodotBaseARInterface::Eyes p_eye, const Transform &p_cam_transform) GODOT_ARKIT_OVERRIDE;
-	virtual CameraMatrix get_projection_for_eye(GodotBaseARInterface::Eyes p_eye, real_t p_aspect, real_t p_z_near, real_t p_z_far) GODOT_ARKIT_OVERRIDE;
+	virtual Transform3D get_transform_for_eye(GodotBaseARInterface::Eyes p_eye, const Transform3D &p_cam_transform) GODOT_ARKIT_OVERRIDE;
+	virtual Projection get_projection_for_eye(GodotBaseARInterface::Eyes p_eye, real_t p_aspect, real_t p_z_near, real_t p_z_far) GODOT_ARKIT_OVERRIDE;
 	virtual void commit_for_eye(GodotBaseARInterface::Eyes p_eye, RID p_render_target, const Rect2 &p_screen_rect) GODOT_ARKIT_OVERRIDE;
 
 	virtual void process() GODOT_ARKIT_OVERRIDE;

--- a/plugins/arkit/arkit_interface.h
+++ b/plugins/arkit/arkit_interface.h
@@ -75,8 +75,6 @@ typedef void GodotARAnchor;
 class ARKitInterface : public GodotBaseARInterface {
 	GDCLASS(ARKitInterface, GodotBaseARInterface);
 
-  static ARKitInterface *instance;
-
 private:
 	bool initialized;
 	bool session_was_started;

--- a/plugins/arkit/arkit_interface.h
+++ b/plugins/arkit/arkit_interface.h
@@ -131,14 +131,45 @@ public:
 	virtual bool is_initialized() const GODOT_ARKIT_OVERRIDE;
 	virtual bool initialize() GODOT_ARKIT_OVERRIDE;
 	virtual void uninitialize() GODOT_ARKIT_OVERRIDE;
+  virtual Dictionary get_system_info() GODOT_ARKIT_OVERRIDE;
+
+ 	virtual PackedStringArray get_suggested_tracker_names() const GODOT_ARKIT_OVERRIDE;
+	virtual PackedStringArray get_suggested_pose_names(const StringName &p_tracker_name) const GODOT_ARKIT_OVERRIDE;
+	virtual TrackingStatus get_tracking_status() const GODOT_ARKIT_OVERRIDE;
+	virtual void trigger_haptic_pulse(const String &p_action_name, const StringName &p_tracker_name, double p_frequency, double p_amplitude, double p_duration_sec, double p_delay_sec = 0) GODOT_ARKIT_OVERRIDE; /* trigger a haptic pulse */
+
+	virtual bool supports_play_area_mode(XRInterface::PlayAreaMode p_mode) GODOT_ARKIT_OVERRIDE;
+	virtual XRInterface::PlayAreaMode get_play_area_mode() const GODOT_ARKIT_OVERRIDE;
+	virtual bool set_play_area_mode(XRInterface::PlayAreaMode p_mode) GODOT_ARKIT_OVERRIDE;
+	virtual PackedVector3Array get_play_area() const GODOT_ARKIT_OVERRIDE;
+
+  virtual bool get_anchor_detection_is_enabled() const GODOT_ARKIT_OVERRIDE;
+	virtual void set_anchor_detection_is_enabled(bool p_enable) GODOT_ARKIT_OVERRIDE;
+	virtual int get_camera_feed_id() GODOT_ARKIT_OVERRIDE;
 
 	virtual Size2 get_render_target_size() GODOT_ARKIT_OVERRIDE;
 	virtual uint32_t get_view_count() GODOT_ARKIT_OVERRIDE;
   virtual Transform3D get_camera_transform() GODOT_ARKIT_OVERRIDE;
 	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) GODOT_ARKIT_OVERRIDE;
 	virtual Projection get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) GODOT_ARKIT_OVERRIDE;
+  virtual RID get_vrs_texture() GODOT_ARKIT_OVERRIDE;
+	virtual RID get_color_texture() GODOT_ARKIT_OVERRIDE;
+	virtual RID get_depth_texture() GODOT_ARKIT_OVERRIDE;
+	virtual RID get_velocity_texture() GODOT_ARKIT_OVERRIDE;
 
 	virtual void process() GODOT_ARKIT_OVERRIDE;
+  virtual void pre_render(){} GODOT_ARKIT_OVERRIDE;
+	virtual bool pre_draw_viewport(RID p_render_target) GODOT_ARKIT_OVERRIDE;
+	virtual Vector<BlitToScreen> post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) GODOT_ARKIT_OVERRIDE;
+	virtual void end_frame() GODOT_ARKIT_OVERRIDE;
+
+  virtual bool is_passthrough_supported() GODOT_ARKIT_OVERRIDE;
+	virtual bool is_passthrough_enabled() GODOT_ARKIT_OVERRIDE;
+	virtual bool start_passthrough() GODOT_ARKIT_OVERRIDE;
+	virtual void stop_passthrough() GODOT_ARKIT_OVERRIDE;
+
+	virtual Array get_supported_environment_blend_modes() GODOT_ARKIT_OVERRIDE;
+	virtual bool set_environment_blend_mode(EnvironmentBlendMode mode) GODOT_ARKIT_OVERRIDE;
 
 	// called by delegate (void * because C++ and Obj-C don't always mix, should really change all platform/ios/*.cpp files to .mm)
 	void _add_or_update_anchor(GodotARAnchor *p_anchor);

--- a/plugins/arkit/arkit_interface.h
+++ b/plugins/arkit/arkit_interface.h
@@ -92,6 +92,10 @@ private:
 	size_t image_height[2];
 	GodotUInt8Vector img_data[2];
 
+#if VERSION_MAJOR == 4
+  XRInterface::TrackingStatus tracking_state;
+#endif
+
 	struct anchor_map {
 		GodotARTracker *tracker;
 		unsigned char uuid[16];

--- a/plugins/arkit/arkit_interface.mm
+++ b/plugins/arkit/arkit_interface.mm
@@ -813,14 +813,23 @@ void ARKitInterface::_add_or_update_anchor(GodotARAnchor *p_anchor) {
 					}
 
 					surftool->generate_normals();
+#if VERSION_MAJOR == 4
+#else
 					tracker->set_mesh(surftool->commit());
+#endif
 				} else {
 					Ref<Mesh> nomesh;
+#if VERSION_MAJOR == 4
+#else
 					tracker->set_mesh(nomesh);
+#endif
 				}
 			} else {
 				Ref<Mesh> nomesh;
+#if VERSION_MAJOR == 4
+#else
 				tracker->set_mesh(nomesh);
+#endif
 			}
 
 			// Note, this also contains a scale factor which gives us an idea of the size of the anchor
@@ -836,8 +845,11 @@ void ARKitInterface::_add_or_update_anchor(GodotARAnchor *p_anchor) {
 			b.rows[0].z = m44.columns[2][0];
 			b.rows[1].z = m44.columns[2][1];
 			b.rows[2].z = m44.columns[2][2];
+#if VERSION_MAJOR == 4
+#else
 			tracker->set_orientation(b);
 			tracker->set_rw_position(Vector3(m44.columns[3][0], m44.columns[3][1], m44.columns[3][2]));
+#endif
 		}
 	}
 }

--- a/plugins/arkit/arkit_interface.mm
+++ b/plugins/arkit/arkit_interface.mm
@@ -178,6 +178,10 @@ real_t ARKitInterface::get_ambient_color_temperature() const {
 	return ambient_color_temperature;
 }
 
+real_t ARKitInterface::get_exposure_offset() const {
+	return exposure_offset;
+}
+
 StringName ARKitInterface::get_name() const {
 	return "ARKit";
 }
@@ -241,6 +245,7 @@ void ARKitInterface::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_ambient_intensity"), &ARKitInterface::get_ambient_intensity);
 	ClassDB::bind_method(D_METHOD("get_ambient_color_temperature"), &ARKitInterface::get_ambient_color_temperature);
+	ClassDB::bind_method(D_METHOD("get_exposure_offset"), &ARKitInterface::get_exposure_offset);
 
 	ClassDB::bind_method(D_METHOD("raycast", "screen_coord"), &ARKitInterface::raycast);
 }
@@ -752,6 +757,13 @@ void ARKitInterface::process() {
 
 				// Process our camera
 				ARCamera *camera = current_frame.camera;
+
+				// Record camera exposure
+				if (@available(iOS 13, *)) {
+					exposure_offset = camera.exposureOffset;
+				} else {
+					exposure_offset = 0.0;
+				}
 
 				// strangely enough we have to states, rolling them up into one
 				if (camera.trackingState == ARTrackingStateNotAvailable) {

--- a/plugins/arkit/arkit_interface.mm
+++ b/plugins/arkit/arkit_interface.mm
@@ -898,6 +898,8 @@ void ARKitInterface::_add_or_update_anchor(GodotARAnchor *p_anchor) {
 			tracker->set_orientation(b);
 			tracker->set_rw_position(Vector3(m44.columns[3][0], m44.columns[3][1], m44.columns[3][2]));
 #endif
+
+			XRServer::get_singleton()->emit_signal(SNAME("tracker_updated"), tracker->get_tracker_name(), tracker->get_tracker_type());
 		}
 	}
 }

--- a/plugins/arkit/arkit_interface.mm
+++ b/plugins/arkit/arkit_interface.mm
@@ -69,6 +69,7 @@
 
 #include <dlfcn.h>
 
+#include "arkit_anchor_mesh.h"
 #include "arkit_interface.h"
 #include "arkit_session_delegate.h"
 
@@ -481,7 +482,7 @@ GodotARTracker *ARKitInterface::get_anchor_for_uuid(const unsigned char *p_uuid)
 	}
 
 #if VERSION_MAJOR == 4
-	XRPositionalTracker *new_tracker = memnew(XRPositionalTracker);
+	ARKitAnchorMesh *new_tracker = memnew(ARKitAnchorMesh);
 	new_tracker->set_tracker_type(XRServer::TRACKER_ANCHOR);
 #else
 	ARVRPositionalTracker *new_tracker = memnew(ARVRPositionalTracker);
@@ -829,7 +830,7 @@ void ARKitInterface::_add_or_update_anchor(GodotARAnchor *p_anchor) {
 		[anchor.identifier getUUIDBytes:uuid];
 
 #if VERSION_MAJOR == 4
-		XRPositionalTracker *tracker = get_anchor_for_uuid(uuid);
+		ARKitAnchorMesh *tracker = get_anchor_for_uuid(uuid);
 #else
 		ARVRPositionalTracker *tracker = get_anchor_for_uuid(uuid);
 #endif
@@ -866,23 +867,15 @@ void ARKitInterface::_add_or_update_anchor(GodotARAnchor *p_anchor) {
 					}
 
 					surftool->generate_normals();
-#if VERSION_MAJOR == 4
-#else
+					
 					tracker->set_mesh(surftool->commit());
-#endif
 				} else {
 					Ref<Mesh> nomesh;
-#if VERSION_MAJOR == 4
-#else
 					tracker->set_mesh(nomesh);
-#endif
 				}
 			} else {
 				Ref<Mesh> nomesh;
-#if VERSION_MAJOR == 4
-#else
 				tracker->set_mesh(nomesh);
-#endif
 			}
 
 			// Note, this also contains a scale factor which gives us an idea of the size of the anchor

--- a/plugins/arkit/arkit_interface.mm
+++ b/plugins/arkit/arkit_interface.mm
@@ -770,7 +770,7 @@ void ARKitInterface::process() {
 
 					///@TODO it's there, but not there.. what to do with this...
 					// https://developer.apple.com/documentation/arkit/arlightestimate?language=objc
-					//				ambient_color_temperature = current_frame.lightEstimate.ambientColorTemperature;
+					ambient_color_temperature = current_frame.lightEstimate.ambientColorTemperature;
 				}
 
 				// Process our camera
@@ -779,8 +779,6 @@ void ARKitInterface::process() {
 				// Record camera exposure
 				if (@available(iOS 13, *)) {
 					exposure_offset = camera.exposureOffset;
-				} else {
-					exposure_offset = 0.0;
 				}
 
 				// strangely enough we have to states, rolling them up into one
@@ -979,6 +977,7 @@ ARKitInterface::ARKitInterface() {
 	num_anchors = 0;
 	ambient_intensity = 1.0;
 	ambient_color_temperature = 1.0;
+	exposure_offset = 0.0;
 	image_width[0] = 0;
 	image_width[1] = 0;
 	image_height[0] = 0;

--- a/plugins/arkit/arkit_interface.mm
+++ b/plugins/arkit/arkit_interface.mm
@@ -371,7 +371,7 @@ uint32_t ARKitInterface::get_view_count() {
 }
 
 Transform3D ARKitInterface::get_camera_transform() {
-	return Transform3D();
+	return transform;
 }
 
 Transform3D ARKitInterface::get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) {
@@ -421,7 +421,7 @@ Vector<BlitToScreen> ARKitInterface::post_draw_viewport(RID p_render_target, con
 
 	// Because we are rendering to our device we must use our main viewport!
 	ERR_FAIL_COND_V(p_screen_rect == Rect2(), blit_to_screen);
-	
+
 	Rect2 src_rect(0.0f, 0.0f, 1.0f, 1.0f);
 	Rect2 dst_rect = p_screen_rect;
 	//Vector2 eye_center(((-intraocular_dist / 2.0) + (display_width / 4.0)) / (display_width / 2.0), 0.0);
@@ -647,11 +647,11 @@ void ARKitInterface::process() {
 							}
 
 #if VERSION_MAJOR == 4
-              img[0].instantiate();
-              img[0]->initialize_data(new_width, new_height, 0, Image::FORMAT_R8, img_data[0]);
+              				img[0].instantiate();
+        					img[0]->initialize_data(new_width, new_height, 0, Image::FORMAT_R8, img_data[0]);
 #else
-              img[0].instance();
-              img[0]->create(new_width, new_height, 0, Image::FORMAT_R8, img_data[0]);
+            				img[0].instance();
+            				img[0]->create(new_width, new_height, 0, Image::FORMAT_R8, img_data[0]);
 #endif
 						}
 
@@ -696,11 +696,11 @@ void ARKitInterface::process() {
 							}
 
 #if VERSION_MAJOR == 4
-              img[1].instantiate();
-              img[1]->initialize_data(new_width, new_height, 0, Image::FORMAT_RG8, img_data[1]);
+            				img[1].instantiate();
+            				img[1]->initialize_data(new_width, new_height, 0, Image::FORMAT_RG8, img_data[1]);
 #else
-              img[1].instance();
-              img[1]->create(new_width, new_height, 0, Image::FORMAT_RG8, img_data[1]);
+            				img[1].instance();
+            				img[1]->create(new_width, new_height, 0, Image::FORMAT_RG8, img_data[1]);
 #endif
 						}
 
@@ -713,20 +713,7 @@ void ARKitInterface::process() {
 
 						// now build our transform to display this as a background image that matches our camera
 						CGAffineTransform affine_transform = [current_frame displayTransformForOrientation:orientation viewportSize:CGSizeMake(screen_size.width, screen_size.height)];
-
-						// we need to invert this, probably row v.s. column notation
-						affine_transform = CGAffineTransformInvert(affine_transform);
-
-						if (orientation != UIInterfaceOrientationPortrait) {
-							affine_transform.b = -affine_transform.b;
-							affine_transform.d = -affine_transform.d;
-							affine_transform.ty = 1.0 - affine_transform.ty;
-						} else {
-							affine_transform.c = -affine_transform.c;
-							affine_transform.a = -affine_transform.a;
-							affine_transform.tx = 1.0 - affine_transform.tx;
-						}
-
+						
 						Transform2D display_transform = Transform2D(
 								affine_transform.a, affine_transform.b,
 								affine_transform.c, affine_transform.d,
@@ -769,12 +756,12 @@ void ARKitInterface::process() {
 					// copy our current frame transform
 					matrix_float4x4 m44 = camera.transform;
 					if (orientation == UIInterfaceOrientationLandscapeLeft) {
-						transform.basis.rows[0].x = m44.columns[0][0];
-						transform.basis.rows[1].x = m44.columns[0][1];
-						transform.basis.rows[2].x = m44.columns[0][2];
-						transform.basis.rows[0].y = m44.columns[1][0];
-						transform.basis.rows[1].y = m44.columns[1][1];
-						transform.basis.rows[2].y = m44.columns[1][2];
+						transform.basis.rows[0].x = -m44.columns[0][0];
+						transform.basis.rows[1].x = -m44.columns[0][1];
+						transform.basis.rows[2].x = -m44.columns[0][2];
+						transform.basis.rows[0].y = -m44.columns[1][0];
+						transform.basis.rows[1].y = -m44.columns[1][1];
+						transform.basis.rows[2].y = -m44.columns[1][2];
 					} else if (orientation == UIInterfaceOrientationPortrait) {
 						transform.basis.rows[0].x = m44.columns[1][0];
 						transform.basis.rows[1].x = m44.columns[1][1];
@@ -783,21 +770,21 @@ void ARKitInterface::process() {
 						transform.basis.rows[1].y = -m44.columns[0][1];
 						transform.basis.rows[2].y = -m44.columns[0][2];
 					} else if (orientation == UIInterfaceOrientationLandscapeRight) {
-						transform.basis.rows[0].x = -m44.columns[0][0];
-						transform.basis.rows[1].x = -m44.columns[0][1];
-						transform.basis.rows[2].x = -m44.columns[0][2];
-						transform.basis.rows[0].y = -m44.columns[1][0];
-						transform.basis.rows[1].y = -m44.columns[1][1];
-						transform.basis.rows[2].y = -m44.columns[1][2];
+						transform.basis.rows[0].x = m44.columns[0][0];
+						transform.basis.rows[1].x = m44.columns[0][1];
+						transform.basis.rows[2].x = m44.columns[0][2];
+						transform.basis.rows[0].y = m44.columns[1][0];
+						transform.basis.rows[1].y = m44.columns[1][1];
+						transform.basis.rows[2].y = m44.columns[1][2];
 					} else if (orientation == UIInterfaceOrientationPortraitUpsideDown) {
-						// this may not be correct
-						transform.basis.rows[0].x = m44.columns[1][0];
-						transform.basis.rows[1].x = m44.columns[1][1];
-						transform.basis.rows[2].x = m44.columns[1][2];
+						transform.basis.rows[0].x = -m44.columns[1][0];
+						transform.basis.rows[1].x = -m44.columns[1][1];
+						transform.basis.rows[2].x = -m44.columns[1][2];
 						transform.basis.rows[0].y = m44.columns[0][0];
 						transform.basis.rows[1].y = m44.columns[0][1];
 						transform.basis.rows[2].y = m44.columns[0][2];
 					}
+					
 					transform.basis.rows[0].z = m44.columns[2][0];
 					transform.basis.rows[1].z = m44.columns[2][1];
 					transform.basis.rows[2].z = m44.columns[2][2];
@@ -807,6 +794,7 @@ void ARKitInterface::process() {
 
 					// copy our current frame projection, investigate using projectionMatrixWithViewportSize:orientation:zNear:zFar: so we can set our own near and far
 					m44 = [camera projectionMatrixForOrientation:orientation viewportSize:CGSizeMake(screen_size.width, screen_size.height) zNear:z_near zFar:z_far];
+
 					projection.columns[0][0] = m44.columns[0][0];
 					projection.columns[1][0] = m44.columns[1][0];
 					projection.columns[2][0] = m44.columns[2][0];

--- a/plugins/arkit/arkit_interface.mm
+++ b/plugins/arkit/arkit_interface.mm
@@ -557,8 +557,6 @@ void ARKitInterface::remove_anchor_for_uuid(const unsigned char *p_uuid) {
 #else
 				ARVRServer::get_singleton()->remove_tracker(anchors[i].tracker);
 #endif
-				memdelete(anchors[i].tracker);
-
 				// bring remaining forward
 				for (unsigned int j = i + 1; j < num_anchors; j++) {
 					anchors[j - 1] = anchors[j];
@@ -581,7 +579,6 @@ void ARKitInterface::remove_all_anchors() {
 #else
 			ARVRServer::get_singleton()->remove_tracker(anchors[i].tracker);
 #endif
-			memdelete(anchors[i].tracker);
 		};
 
 		free(anchors);

--- a/plugins/arkit/arkit_interface.mm
+++ b/plugins/arkit/arkit_interface.mm
@@ -179,7 +179,7 @@ StringName ARKitInterface::get_name() const {
 	return "ARKit";
 }
 
-int ARKitInterface::get_capabilities() const {
+uint32_t ARKitInterface::get_capabilities() const {
 #if VERSION_MAJOR == 4
 	return ARKitInterface::XR_MONO + ARKitInterface::XR_AR;
 #else
@@ -242,10 +242,12 @@ void ARKitInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("raycast", "screen_coord"), &ARKitInterface::raycast);
 }
 
+#if VERSION_MAJOR != 4
 bool ARKitInterface::is_stereo() {
 	// this is a mono device...
 	return false;
 }
+#endif
 
 bool ARKitInterface::is_initialized() const {
 	return initialized;
@@ -281,7 +283,7 @@ bool ARKitInterface::initialize() {
 			ar_session.delegate = ar_delegate;
 
 			// reset our transform
-			transform = Transform();
+			transform = Transform3D();
 
 			// make this our primary interface
 			ar_server->set_primary_interface(this);
@@ -587,10 +589,11 @@ void ARKitInterface::process() {
 
 #if VERSION_MAJOR == 4
               img[0].instantiate();
+              img[0]->initialize_data(new_width, new_height, 0, Image::FORMAT_R8, img_data[0]);
 #else
               img[0].instance();
+              img[0]->create(new_width, new_height, 0, Image::FORMAT_R8, img_data[0]);
 #endif
-							img[0]->create(new_width, new_height, 0, Image::FORMAT_R8, img_data[0]);
 						}
 
 						{
@@ -635,10 +638,11 @@ void ARKitInterface::process() {
 
 #if VERSION_MAJOR == 4
               img[1].instantiate();
+              img[1]->initialize_data(new_width, new_height, 0, Image::FORMAT_RG8, img_data[1]);
 #else
               img[1].instance();
+              img[1]->create(new_width, new_height, 0, Image::FORMAT_RG8, img_data[1]);
 #endif
-							img[1]->create(new_width, new_height, 0, Image::FORMAT_RG8, img_data[1]);
 						}
 
 						// set our texture...
@@ -740,22 +744,22 @@ void ARKitInterface::process() {
 
 					// copy our current frame projection, investigate using projectionMatrixWithViewportSize:orientation:zNear:zFar: so we can set our own near and far
 					m44 = [camera projectionMatrixForOrientation:orientation viewportSize:CGSizeMake(screen_size.width, screen_size.height) zNear:z_near zFar:z_far];
-					projection.matrix[0][0] = m44.columns[0][0];
-					projection.matrix[1][0] = m44.columns[1][0];
-					projection.matrix[2][0] = m44.columns[2][0];
-					projection.matrix[3][0] = m44.columns[3][0];
-					projection.matrix[0][1] = m44.columns[0][1];
-					projection.matrix[1][1] = m44.columns[1][1];
-					projection.matrix[2][1] = m44.columns[2][1];
-					projection.matrix[3][1] = m44.columns[3][1];
-					projection.matrix[0][2] = m44.columns[0][2];
-					projection.matrix[1][2] = m44.columns[1][2];
-					projection.matrix[2][2] = m44.columns[2][2];
-					projection.matrix[3][2] = m44.columns[3][2];
-					projection.matrix[0][3] = m44.columns[0][3];
-					projection.matrix[1][3] = m44.columns[1][3];
-					projection.matrix[2][3] = m44.columns[2][3];
-					projection.matrix[3][3] = m44.columns[3][3];
+					projection.columns[0][0] = m44.columns[0][0];
+					projection.columns[1][0] = m44.columns[1][0];
+					projection.columns[2][0] = m44.columns[2][0];
+					projection.columns[3][0] = m44.columns[3][0];
+					projection.columns[0][1] = m44.columns[0][1];
+					projection.columns[1][1] = m44.columns[1][1];
+					projection.columns[2][1] = m44.columns[2][1];
+					projection.columns[3][1] = m44.columns[3][1];
+					projection.columns[0][2] = m44.columns[0][2];
+					projection.columns[1][2] = m44.columns[1][2];
+					projection.columns[2][2] = m44.columns[2][2];
+					projection.columns[3][2] = m44.columns[3][2];
+					projection.columns[0][3] = m44.columns[0][3];
+					projection.columns[1][3] = m44.columns[1][3];
+					projection.columns[2][3] = m44.columns[2][3];
+					projection.columns[3][3] = m44.columns[3][3];
 				}
 			}
 		}

--- a/plugins/arkit/arkit_interface.mm
+++ b/plugins/arkit/arkit_interface.mm
@@ -79,6 +79,8 @@ ARSession *ar_session;
 ARKitSessionDelegate *ar_delegate;
 NSTimeInterval last_timestamp;
 
+ARKitInterface *ARKitInterface::instance = NULL;
+
 /* this is called when we initialize or when we come back from having our app pushed to the background, just (re)start our session */
 void ARKitInterface::start_session() {
 	// We're active...
@@ -879,6 +881,9 @@ void ARKitInterface::_remove_anchor(GodotARAnchor *p_anchor) {
 }
 
 ARKitInterface::ARKitInterface() {
+	ERR_FAIL_COND(instance != NULL);
+	instance = this;
+
 	initialized = false;
 	session_was_started = false;
 	plane_detection_is_enabled = false;

--- a/plugins/arkit/arkit_interface.mm
+++ b/plugins/arkit/arkit_interface.mm
@@ -79,8 +79,6 @@ ARSession *ar_session;
 ARKitSessionDelegate *ar_delegate;
 NSTimeInterval last_timestamp;
 
-ARKitInterface *ARKitInterface::instance = NULL;
-
 /* this is called when we initialize or when we come back from having our app pushed to the background, just (re)start our session */
 void ARKitInterface::start_session() {
 	// We're active...
@@ -881,9 +879,6 @@ void ARKitInterface::_remove_anchor(GodotARAnchor *p_anchor) {
 }
 
 ARKitInterface::ARKitInterface() {
-	ERR_FAIL_COND(instance != NULL);
-	instance = this;
-
 	initialized = false;
 	session_was_started = false;
 	plane_detection_is_enabled = false;

--- a/plugins/arkit/arkit_interface.mm
+++ b/plugins/arkit/arkit_interface.mm
@@ -94,12 +94,14 @@ void ARKitInterface::start_session() {
 
 			configuration.lightEstimationEnabled = light_estimation_is_enabled;
 			if (plane_detection_is_enabled) {
+				print_line("Starting plane detection");
 				if (@available(iOS 11.3, *)) {
 					configuration.planeDetection = ARPlaneDetectionVertical | ARPlaneDetectionHorizontal;
 				} else {
 					configuration.planeDetection = ARPlaneDetectionHorizontal;
 				}
 			} else {
+				print_line("Plane detection is disabled");
 				configuration.planeDetection = 0;
 			}
 
@@ -843,9 +845,9 @@ void ARKitInterface::_add_or_update_anchor(GodotARAnchor *p_anchor) {
 				if (planeAnchor.geometry.triangleCount > 0) {
 					Ref<SurfaceTool> surftool;
 #if VERSION_MAJOR == 4
-          surftool.instantiate();
+    				surftool.instantiate();
 #else
-          surftool.instance();
+        			surftool.instance();
 #endif
 					surftool->begin(Mesh::PRIMITIVE_TRIANGLES);
 
@@ -897,6 +899,8 @@ void ARKitInterface::_add_or_update_anchor(GodotARAnchor *p_anchor) {
 			b.rows[1].z = m44.columns[2][1];
 			b.rows[2].z = m44.columns[2][2];
 #if VERSION_MAJOR == 4
+			Transform3D pose = Transform3D(b, Vector3(m44.columns[3][0], m44.columns[3][1], m44.columns[3][2]));
+			tracker->set_pose("default", pose, Vector3(), Vector3());
 #else
 			tracker->set_orientation(b);
 			tracker->set_rw_position(Vector3(m44.columns[3][0], m44.columns[3][1], m44.columns[3][2]));

--- a/plugins/arkit/arkit_interface.mm
+++ b/plugins/arkit/arkit_interface.mm
@@ -349,6 +349,11 @@ void ARKitInterface::uninitialize() {
 	}
 }
 
+Dictionary ARKitInterface::get_system_info() {
+	Dictionary dict;
+	return dict;
+}
+
 Size2 ARKitInterface::get_render_target_size() {
 	GODOT_MAKE_THREAD_SAFE
 
@@ -359,6 +364,14 @@ Size2 ARKitInterface::get_render_target_size() {
 #endif
 
 	return target_size;
+}
+
+uint32_t ARKitInterface::get_view_count() {
+	return 1;
+}
+
+Transform3D ARKitInterface::get_camera_transform() {
+	return Transform3D();
 }
 
 Transform3D ARKitInterface::get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) {
@@ -396,6 +409,11 @@ Projection ARKitInterface::get_projection_for_view(uint32_t p_view, double p_asp
 	z_far = p_z_far;
 
 	return projection;
+}
+
+Vector<BlitToScreen> ARKitInterface::post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) {
+	Vector<BlitToScreen> blit_to_screen;
+	return blit_to_screen;
 }
 
 GodotARTracker *ARKitInterface::get_anchor_for_uuid(const unsigned char *p_uuid) {
@@ -646,7 +664,11 @@ void ARKitInterface::process() {
 						}
 
 						// set our texture...
+#if VERSION_MAJOR == 4 && VERSION_MINOR >= 4
+						feed->set_ycbcr_images(img[0], img[1]);
+#else
 						feed->set_YCbCr_imgs(img[0], img[1]);
+#endif
 
 						// now build our transform to display this as a background image that matches our camera
 						CGAffineTransform affine_transform = [current_frame displayTransformForOrientation:orientation viewportSize:CGSizeMake(screen_size.width, screen_size.height)];

--- a/plugins/arkit/arkit_interface.mm
+++ b/plugins/arkit/arkit_interface.mm
@@ -222,7 +222,7 @@ Array ARKitInterface::raycast(Vector2 p_screen_coord) {
 		NSArray<ARHitTestResult *> *results = [ar_session.currentFrame hitTest:point types:ARHitTestResultTypeExistingPlaneUsingExtent];
 
 		for (ARHitTestResult *result in results) {
-			Transform transform;
+			Transform3D transform;
 
 			matrix_float4x4 m44 = result.worldTransform;
 			transform.basis.elements[0].x = m44.columns[0][0];
@@ -374,10 +374,10 @@ Size2 ARKitInterface::get_render_targetsize() {
 	return target_size;
 }
 
-Transform ARKitInterface::get_transform_for_eye(GodotBaseARInterface::Eyes p_eye, const Transform &p_cam_transform) {
+Transform3D ARKitInterface::get_transform_for_eye(GodotBaseARInterface::Eyes p_eye, const Transform3D &p_cam_transform) {
 	GODOT_MAKE_THREAD_SAFE
 
-	Transform transform_for_eye;
+	Transform3D transform_for_eye;
 
 #if VERSION_MAJOR == 4
 	XRServer *ar_server = XRServer::get_singleton();
@@ -403,7 +403,7 @@ Transform ARKitInterface::get_transform_for_eye(GodotBaseARInterface::Eyes p_eye
 	return transform_for_eye;
 }
 
-CameraMatrix ARKitInterface::get_projection_for_eye(GodotBaseARInterface::Eyes p_eye, real_t p_aspect, real_t p_z_near, real_t p_z_far) {
+Projection ARKitInterface::get_projection_for_eye(GodotBaseARInterface::Eyes p_eye, real_t p_aspect, real_t p_z_near, real_t p_z_far) {
 	// Remember our near and far, it will be used in process when we obtain our projection from our ARKit session.
 	z_near = p_z_near;
 	z_far = p_z_far;

--- a/plugins/arkit/arkit_module.cpp
+++ b/plugins/arkit/arkit_module.cpp
@@ -39,7 +39,7 @@ void register_arkit_types() {
 	Ref<ARKitInterface> arkit_interface;
 
 #if VERSION_MAJOR == 4
-	arkit_interface.instantiate();
+  arkit_interface.instantiate();
 	XRServer::get_singleton()->add_interface(arkit_interface);
 #else
 	arkit_interface.instance();

--- a/plugins/arkit/arkit_module.cpp
+++ b/plugins/arkit/arkit_module.cpp
@@ -37,11 +37,12 @@ void register_arkit_types() {
 	// does it make sense to register the class?
 
 	Ref<ARKitInterface> arkit_interface;
-	arkit_interface.instance();
 
 #if VERSION_MAJOR == 4
+	arkit_interface.instantiate();
 	XRServer::get_singleton()->add_interface(arkit_interface);
 #else
+	arkit_interface.instance();
 	ARVRServer::get_singleton()->add_interface(arkit_interface);
 #endif
 }

--- a/plugins/arkit/arkit_module.cpp
+++ b/plugins/arkit/arkit_module.cpp
@@ -33,14 +33,18 @@
 #include "arkit_interface.h"
 #include "core/version.h"
 
+#include "core/object/class_db.h"
+
 void register_arkit_types() {
 	// does it make sense to register the class?
 
 	Ref<ARKitInterface> arkit_interface;
 
 #if VERSION_MAJOR == 4
-  arkit_interface.instantiate();
+	arkit_interface.instantiate();
 	XRServer::get_singleton()->add_interface(arkit_interface);
+	//GDREGISTER_CLASS(ARKitAnchorMesh);
+	ClassDB::register_class<ARKitAnchorMesh>();
 #else
 	arkit_interface.instance();
 	ARVRServer::get_singleton()->add_interface(arkit_interface);

--- a/scripts/generate_headers.sh
+++ b/scripts/generate_headers.sh
@@ -5,5 +5,5 @@ then
         ./../scripts/timeout scons platform=iphone target=release_debug
 else
     cd ./godot && \
-        ./../scripts/timeout scons platform=ios target=release_debug
+        ./../scripts/timeout scons platform=ios target=template_debug
 fi


### PR DESCRIPTION
Continues #64

So far I tried to do the minimum amount of work to get this working in Godot 4.x. We should consider porting it to a GDExtension as mux213 suggested

https://github.com/user-attachments/assets/905866e3-12df-4f50-930d-ba912c65289e


Demo project
https://github.com/celyk/godot_xr_test_projects/tree/master/ARKit

What's working
- Basic AR
- Screen orientations (provided feed_transform is used to adjust the camera feed)
- Anchor positions
- Anchor plane mesh
- ARKit [hitTest](https://developer.apple.com/documentation/arkit/arframe/hittest(_:types:)) for touching anchors

What's not working
- With background_camera_feed_id set color and orientation are wrong
- Standard Godot ray intersect (Wrong camera FOV?)