### PR TITLE
Fixed build errors from new apple embedded modifications and for 4.5beta1

### DIFF
--- a/plugins/apn/apn.mm
+++ b/plugins/apn/apn.mm
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "apn.h"
+#import "godot_apn_delegate.h"
 
 #import <Foundation/Foundation.h>
 
@@ -40,7 +41,7 @@
 #include "core/project_settings.h"
 #endif
 
-#import "godot_apn_delegate.h"
+#import "drivers/apple_embedded/godot_app_delegate.h"
 
 static APNPlugin *singleton;
 

--- a/plugins/apn/godot_apn_delegate.mm
+++ b/plugins/apn/godot_apn_delegate.mm
@@ -28,25 +28,24 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#import "godot_apn_delegate.h"
 
 #include "apn.h"
-
+#import "godot_apn_delegate.h"
 #import "godot_user_notification_delegate.h"
 
 #if VERSION_MAJOR == 4
-#import "platform/ios/godot_app_delegate.h"
+#import "drivers/apple_embedded/godot_app_delegate.h"
 #else
-#import "platform/iphone/godot_app_delegate.h"
+#import "godot_app_delegate.h"
 #endif
 
 struct APNSInitializer {
 
 	APNSInitializer() {
 #if VERSION_MAJOR == 4 && VERSION_MINOR >= 4
-		[GodotApplicationDelegate addService:[GodotAPNAppDelegate shared]];
+		[GDTApplicationDelegate addService:[GodotAPNAppDelegate shared]];
 #else
-		[GodotApplicalitionDelegate addService:[GodotAPNAppDelegate shared]];
+		[GDTApplicationDelegate addService:[GodotAPNAppDelegate shared]];
 #endif
 	}
 };
@@ -94,7 +93,7 @@ static APNSInitializer initializer;
 	}
 
 	String device_token;
-	device_token.parse_utf8([[token copy] UTF8String]);
+	device_token.append_utf8([[token copy] UTF8String]);
 
 	APNPlugin::get_singleton()->update_device_token(device_token);
 }

--- a/plugins/apn/godot_app_delegate_extension.h
+++ b/plugins/apn/godot_app_delegate_extension.h
@@ -31,15 +31,15 @@
 #include "core/version.h"
 
 #if VERSION_MAJOR == 4
-#import "platform/ios/godot_app_delegate.h"
+#import "drivers/apple_embedded/godot_app_delegate.h"
 #else
 #import "platform/iphone/godot_app_delegate.h"
 #endif
 
 #if VERSION_MAJOR == 4 && VERSION_MINOR >= 4
-@interface GodotApplicationDelegate (PushNotifications)
+@interface GDTApplicationDelegate (PushNotifications)
 #else
-@interface GodotApplicalitionDelegate (PushNotifications)
+@interface GDTApplicationDelegate (PushNotifications)
 #endif
 
 @end

--- a/plugins/apn/godot_app_delegate_extension.m
+++ b/plugins/apn/godot_app_delegate_extension.m
@@ -31,10 +31,10 @@
 #include "godot_app_delegate_extension.h"
 
 #if VERSION_MAJOR == 4 && VERSION_MINOR >= 4
-@implementation GodotApplicationDelegate (PushNotifications)
+@implementation GDTApplicationDelegate (PushNotifications)
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
-	for (ApplicationDelegateService *service in GodotApplicationDelegate.services) {
+	for (GDTAppDelegateServiceProtocol *service in GDTApplicationDelegate.services) {
 		if (![service respondsToSelector:_cmd]) {
 			continue;
 		}
@@ -44,7 +44,7 @@
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
-	for (ApplicationDelegateService *service in GodotApplicationDelegate.services) {
+	for (GDTAppDelegateServiceProtocol *service in GDTApplicationDelegate.services) {
 		if (![service respondsToSelector:_cmd]) {
 			continue;
 		}
@@ -54,7 +54,7 @@
 }
 
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
-	for (ApplicationDelegateService *service in GodotApplicationDelegate.services) {
+	for (GDTAppDelegateServiceProtocol *service in GDTApplicationDelegate.services) {
 		if (![service respondsToSelector:_cmd]) {
 			continue;
 		}
@@ -69,10 +69,10 @@
 
 #else
 
-@implementation GodotApplicalitionDelegate (PushNotifications)
+@implementation GDTApplicationDelegate (PushNotifications)
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
-	for (ApplicationDelegateService *service in GodotApplicalitionDelegate.services) {
+	for (GDTAppDelegateServiceProtocol *service in GDTApplicationDelegate.services) {
 		if (![service respondsToSelector:_cmd]) {
 			continue;
 		}
@@ -82,7 +82,7 @@
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
-	for (ApplicationDelegateService *service in GodotApplicalitionDelegate.services) {
+	for (GDTAppDelegateServiceProtocol *service in GDTApplicationDelegate.services) {
 		if (![service respondsToSelector:_cmd]) {
 			continue;
 		}
@@ -92,7 +92,7 @@
 }
 
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
-	for (ApplicationDelegateService *service in GodotApplicalitionDelegate.services) {
+	for (GDTAppDelegateServiceProtocol *service in GDTApplicationDelegate.services) {
 		if (![service respondsToSelector:_cmd]) {
 			continue;
 		}

--- a/plugins/photo_picker/photo_picker.mm
+++ b/plugins/photo_picker/photo_picker.mm
@@ -34,8 +34,8 @@
 #import <Photos/Photos.h>
 
 #if VERSION_MAJOR == 4
-#import "platform/ios/app_delegate.h"
-#import "platform/ios/view_controller.h"
+#import "drivers/apple_embedded/godot_app_delegate.h"
+#import "drivers/apple_embedded/view_controller.h"
 #else
 #import "platform/iphone/app_delegate.h"
 #import "platform/iphone/view_controller.h"


### PR DESCRIPTION
Allows `apn` and `photo_picker` to build after the apple embedded PR [#105628](https://github.com/godotengine/godot/pull/105628) was merged.

Tested on 4.5beta1.

Also allows apn to build for Godot 4.5 after `parse_utf8` was renamed to `append_utf8`.

These changes will not be backward compatible to versions before 4.5beta1. The build scripts also require updating.

I haven't fixed the remaining plugins, but the changes in this PR should make it easy to get them working.