### PR TITLE
4.6-stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ jobs:
 
       - name: Generate Headers
         run: |
-          ./scripts/generate_headers.sh 3.x || true
+          ./scripts/generate_headers.sh 4.x || true
 
       - name: Compile Plugins
         run: |
-          ./scripts/release_xcframework.sh 3.x
+          ./scripts/release_xcframework.sh 4.x
           ls -l bin/release
 
       - uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Once the actual compilation starts, you can stop this command by pressing <kbd>C
 - Run the command below to generate an `.a` static library for chosen target:
 
 ```bash
-scons target=<debug|release|release_debug> arch=<arch> simulator=<no|yes> plugin=<plugin_name> version=<3.x|4.0>
+scons target=<debug|release|release_debug> arch=<arch> simulator=<no|yes> plugin=<plugin_name> version=<3.x|4.x>
 ```
 
 **Note:** Godot's official `debug` export templates are compiled with the `release_debug` target, *not* the `debug` target.

--- a/SConstruct
+++ b/SConstruct
@@ -25,7 +25,7 @@ opts.Add(BoolVariable('simulator', "Compilation platform", 'no'))
 opts.Add(BoolVariable('use_llvm', "Use the LLVM / Clang compiler", 'no'))
 opts.Add(PathVariable('target_path', 'The path where the lib is installed.', 'bin/'))
 opts.Add(EnumVariable('plugin', 'Plugin to build', '', ['', 'apn', 'arkit', 'camera', 'icloud', 'gamecenter', 'inappstore', 'photo_picker']))
-opts.Add(EnumVariable('version', 'Godot version to target', '', ['', '3.x', '4.0']))
+opts.Add(EnumVariable('version', 'Godot version to target', '', ['', '3.x', '4.x']))
 
 # Updates the environment with the option variables.
 opts.Update(env)
@@ -116,7 +116,7 @@ if env['version'] == '3.x':
         ])
 
         env.Prepend(CXXFLAGS=['-fomit-frame-pointer'])
-elif env['version'] == '4.0':
+elif env['version'] == '4.x':
     env.Prepend(CFLAGS=['-std=gnu11'])
     env.Prepend(CXXFLAGS=['-DVULKAN_ENABLED', '-std=gnu++17'])
 
@@ -144,7 +144,7 @@ else:
     print("No valid version to set flags for.")
     quit();
 
-if env['version'] == '4.0' and env['plugin'] == 'arkit':
+if env['version'] == '4.x' and env['plugin'] == 'arkit':
     print("'arkit' plugin is 3.x only.")
     quit();
 

--- a/scripts/generate_headers.sh
+++ b/scripts/generate_headers.sh
@@ -5,5 +5,5 @@ then
         ./../scripts/timeout scons platform=iphone target=release_debug
 else
     cd ./godot && \
-        ./../scripts/timeout scons platform=ios target=release_debug
+        ./../scripts/timeout scons platform=ios target=template_release
 fi


### PR DESCRIPTION
A minimal change PR to simply update 4.0 to 4.x

* Changed subrepo to target godot [tag/4.6.1-stable](https://github.com/godotengine/godot/releases/tag/4.6.1-stable)
* updated references from `4.0` to `4.x`
* tested build locally on M3 MacbookPro