### PR TITLE
gamecenter: pop_pending_event fix crash

### DIFF
--- a/plugins/gamecenter/game_center.mm
+++ b/plugins/gamecenter/game_center.mm
@@ -387,10 +387,18 @@ int GameCenter::get_pending_event_count() {
 };
 
 Variant GameCenter::pop_pending_event() {
-	Variant front = pending_events.front()->get();
+	List<Variant>::Element* front = pending_events.front();
+	if (front == nullptr) {
+		Dictionary ret;
+		ret["type"] = "pop_pending_event";
+		ret["result"] = "error";
+		ret["error_code"] = ERR_PARAMETER_RANGE_ERROR;
+		ret["error_description"] = "Range error: There are 0 pending events, use get_pending_event_count() to query the size before calling pop_pending_event().";
+		return ret;
+	}
+	Variant result = front->get();
 	pending_events.pop_front();
-
-	return front;
+	return result;
 };
 
 GameCenter *GameCenter::get_singleton() {


### PR DESCRIPTION
Fix a crash when calling pop_pending_event from godot.

Code to reproduce crash:
```gd
func _ready() -> void:
	if Engine.has_singleton("GameCenter"):
		print("initializing GameCenter")
		var game_center = Engine.get_singleton("GameCenter")
		game_center.authenticate()
		print("Game Center event: ", game_center.pop_pending_event())
```

## Before:
Crashes with EXC_BAD_ACCESS
<img width="1190" height="395" alt="Screenshot 2026-03-03 at 11 24 14 PM" src="https://github.com/user-attachments/assets/d325f56d-18d5-4bbc-83e9-2d0e6d7822fa" />

## After:
<img width="1045" height="49" alt="Screenshot 2026-03-03 at 11 27 29 PM" src="https://github.com/user-attachments/assets/76b0c930-ec1d-4829-ba43-6c6a3b8050b5" />
Returns an event with `"result": "error"` which would be expected by error handling code consistent with other events.
