### PR TITLE
gamecenter: refactor achievements

### DIFF
--- a/plugins/gamecenter/README.md
+++ b/plugins/gamecenter/README.md
@@ -2,24 +2,115 @@
 
 ## Methods
 
-### Authorization
+### Authentication
 
-`authenticate()` - Performs user authentication.  
-`is_authenticated()` - Returns authentication state.  
+* `authenticate()` - Performs user authentication.
+* `is_authenticated()` - Returns authentication state.
 
-### GameCenter methods
+### Leaderboards
 
-`post_score(Dictionary score_dictionary)` - Reports a score data to iOS `GameCenter`. Generates new event with `post_score` type.  
-`award_achievement(Dictionary achievent_dictionary)` - Reports progress of achievement data to iOS `GameCenter`. Generates new event with `award_achievement` type.  
-`reset_achievements()` - Resets all achievement progress for the local player. Generates new event with `reset_achievements` type.  
-`request_achievements()` - Loads previously submitted achievement progress for the local player from iOS `GameCenter`. Generates new event with `achievements` type.  
-`request_achievement_descriptions()` - Downloads the achievement descriptions from iOS `GameCenter`. Generates new event with `achievement_descriptions` type.  
-`show_game_center(Dictionary screen_dictionary)` - Displays Game Center information of your game. Generates new event with `show_game_center` type when information screen closes.  
-`request_identity_verification_signature()` -  Creates a signature for a third-party server to authenticate the local player. Generates new event with `identity_verification_signature` type.  
+* `post_score(Dictionary score_dictionary)` - Reports a score data to `Game Center`. Generates new event with `post_score` type.
 
-## Properties
+### Achievements
+
+* `report_achievement(String identifier, double percent_complete, bool shows_completion_banner)` - Reports progress of achievement data to `Game Center`.
+If `percent_complete` is [100.0, then the achievement is awarded](https://developer.apple.com/documentation/gamekit/gkachievement/percentcomplete?language=objc).
+When `shows_completion_banner` is false, the native Game Center UI won't trigger so you can implement your own UI.
+Docs: https://developer.apple.com/documentation/gamekit/rewarding-players-with-achievements?language=objc
+Returns results via an event with the type `report_achievement`.
+```gd
+{
+	"type": "report_achievement",
+	"result": "ok",
+}
+```
+
+* `reset_achievements()` - Resets all achievement progress for the local player. Returns results via an event with the type `reset_achievements`.
+Docs: https://developer.apple.com/documentation/gamekit/gkachievement/resetachievements(completionhandler:)?language=objc
+```gd
+{
+	"type": "reset_achievements",
+	"result": "ok",
+}
+```
+
+* `load_achievements()` - Loads previously submitted achievement progress for the local player from `Game Center`.
+Returns results via an event with the type `load_achievements`.
+```gd
+{
+	"type": "load_achievements",
+	"result": "ok",
+	"achievements": [
+		{
+			"identifier": String,
+			"percent_complete": double,
+			"completed": bool,
+			"last_reported_date": String, # ISO 8601 date: "2025-12-02T16:59:31Z"
+		},
+		...
+	],
+}
+```
+
+* `load_achievement_descriptions()` - Downloads the achievement descriptions from `Game Center`.  This includes achievements that the player has not achieved.
+Docs: https://developer.apple.com/documentation/gamekit/gkachievementdescription/loadachievementdescriptions(completionhandler:)?language=objc
+Returns results in an event with the type `load_achievement_descriptions`.
+```gd
+{
+	"type": "load_achievement_descriptions",
+	"result": "ok",
+	"descriptions": [
+		{
+			"identifier": String,
+			"title": String,
+			"unachieved_description": String,
+			"achieved_description": String,
+			"maximum_points": int64,
+			"hidden": bool,
+			"replayable": bool,
+		},
+		...
+	],
+}
+```
+
+### Native Game Center UI
+
+* `show_game_center(Dictionary screen_dictionary)` - Displays Game Center information of your game. Generates new event with `show_game_center` type when information screen closes.
+Docs: https://developer.apple.com/documentation/gamekit/gkgamecentercontrollerdelegate/gamecenterviewcontrollerdidfinish(_:)?language=objc
+```gd
+{
+	"type": "show_game_center",
+	"result": "ok",
+}
+```
+
+* `request_identity_verification_signature()` -  Creates a signature for a third-party server to authenticate the local player.
+Docs: https://developer.apple.com/documentation/gamekit/gklocalplayer/fetchitems(foridentityverificationsignature:)?language=objc
+Returns results in an event with the type `identity_verification_signature`.
+```gd
+{
+	"type": "identity_verification_signature",
+	"result": "ok",
+	"public_key_url": String,
+	"signature": String, # base64 encoded
+	"salt": String, # base64 encoded
+	"timestamp": uint64,
+	"player_id": String, # teamPlayerID
+}
+```
 
 ## Events reporting
 
 `get_pending_event_count()` - Returns number of events pending from plugin to be processed.  
 `pop_pending_event()` - Returns first unprocessed plugin event.  
+
+An error event is in the following format:
+```gd
+{
+	"type": String,
+	"result": "error",
+	"error_code": int64,
+	"error_description": String,
+}
+```

--- a/plugins/gamecenter/game_center.h
+++ b/plugins/gamecenter/game_center.h
@@ -53,18 +53,30 @@ class GameCenter : public Object {
 	void return_connect_error(const char *p_error_description);
 
 public:
+	// Authentication
+
 	Error authenticate();
 	bool is_authenticated();
 
+	// Leaderboards
+
 	Error post_score(Dictionary p_score);
-	Error award_achievement(Dictionary p_params);
+
+	// Achievements
+
+	Error report_achievement(String identifier, double percent_complete, bool shows_completion_banner);
 	void reset_achievements();
-	void request_achievements();
-	void request_achievement_descriptions();
+	void load_achievements();
+	void load_achievement_descriptions();
+
+	// Native Game Center UI
+
 	Error show_game_center(Dictionary p_params);
 	Error request_identity_verification_signature();
 
 	void game_center_closed();
+
+	// Event Handling
 
 	int get_pending_event_count();
 	Variant pop_pending_event();

--- a/plugins/gamecenter/game_center.mm
+++ b/plugins/gamecenter/game_center.mm
@@ -68,16 +68,18 @@ void GameCenter::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_authenticated"), &GameCenter::is_authenticated);
 
 	ClassDB::bind_method(D_METHOD("post_score"), &GameCenter::post_score);
-	ClassDB::bind_method(D_METHOD("award_achievement", "achievement"), &GameCenter::award_achievement);
+	ClassDB::bind_method(D_METHOD("report_achievement", "identifier", "percent_complete", "shows_completion_banner"), &GameCenter::report_achievement);
 	ClassDB::bind_method(D_METHOD("reset_achievements"), &GameCenter::reset_achievements);
-	ClassDB::bind_method(D_METHOD("request_achievements"), &GameCenter::request_achievements);
-	ClassDB::bind_method(D_METHOD("request_achievement_descriptions"), &GameCenter::request_achievement_descriptions);
+	ClassDB::bind_method(D_METHOD("load_achievements"), &GameCenter::load_achievements);
+	ClassDB::bind_method(D_METHOD("load_achievement_descriptions"), &GameCenter::load_achievement_descriptions);
 	ClassDB::bind_method(D_METHOD("show_game_center"), &GameCenter::show_game_center);
 	ClassDB::bind_method(D_METHOD("request_identity_verification_signature"), &GameCenter::request_identity_verification_signature);
 
 	ClassDB::bind_method(D_METHOD("get_pending_event_count"), &GameCenter::get_pending_event_count);
 	ClassDB::bind_method(D_METHOD("pop_pending_event"), &GameCenter::pop_pending_event);
 };
+
+// Authentication
 
 Error GameCenter::authenticate() {
 	//if this class isn't available, game center isn't implemented
@@ -136,6 +138,8 @@ bool GameCenter::is_authenticated() {
 	return authenticated;
 };
 
+// Leaderboards
+
 Error GameCenter::post_score(Dictionary p_score) {
 	ERR_FAIL_COND_V(!p_score.has("score") || !p_score.has("category"), ERR_INVALID_PARAMETER);
 	float score = p_score["score"];
@@ -165,118 +169,83 @@ Error GameCenter::post_score(Dictionary p_score) {
 	return OK;
 };
 
-Error GameCenter::award_achievement(Dictionary p_params) {
-	ERR_FAIL_COND_V(!p_params.has("name") || !p_params.has("progress"), ERR_INVALID_PARAMETER);
-	String name = p_params["name"];
-	float progress = p_params["progress"];
+// Achievements
 
-	NSString *name_str = [[NSString alloc] initWithUTF8String:name.utf8().get_data()];
-	GKAchievement *achievement = [[GKAchievement alloc] initWithIdentifier:name_str];
+Error GameCenter::report_achievement(String identifier, double percent_complete, bool shows_completion_banner) {
+	NSString *identifier_nsstring = [[NSString alloc] initWithUTF8String: identifier.utf8().get_data()];
+	GKAchievement *achievement = [[GKAchievement alloc] initWithIdentifier: identifier_nsstring];
 	ERR_FAIL_COND_V(!achievement, FAILED);
 
-	ERR_FAIL_COND_V([GKAchievement respondsToSelector:@selector(reportAchievements)], ERR_UNAVAILABLE);
+	achievement.percentComplete = percent_complete;
+	achievement.showsCompletionBanner = shows_completion_banner;
 
-	achievement.percentComplete = progress;
-	achievement.showsCompletionBanner = NO;
-	if (p_params.has("show_completion_banner")) {
-		achievement.showsCompletionBanner = p_params["show_completion_banner"] ? YES : NO;
-	}
-
-	[GKAchievement reportAchievements:@[ achievement ]
-				withCompletionHandler:^(NSError *error) {
+	[GKAchievement reportAchievements: @[ achievement ]
+				withCompletionHandler: ^(NSError *error) {
 					Dictionary ret;
-					ret["type"] = "award_achievement";
+					ret["type"] = "report_achievement";
 					if (error == nil) {
 						ret["result"] = "ok";
 					} else {
 						ret["result"] = "error";
 						ret["error_code"] = (int64_t)error.code;
-					};
-
+						ret["error_description"] = [error.localizedDescription UTF8String];
+					}
 					pending_events.push_back(ret);
 				}];
-
 	return OK;
-};
+}
 
-void GameCenter::request_achievement_descriptions() {
-	[GKAchievementDescription loadAchievementDescriptionsWithCompletionHandler:^(NSArray *descriptions, NSError *error) {
+void GameCenter::load_achievements() {
+	[GKAchievement loadAchievementsWithCompletionHandler:^(NSArray<GKAchievement *> *achievements, NSError *error) {
 		Dictionary ret;
-		ret["type"] = "achievement_descriptions";
+		ret["type"] = "load_achievements";
+		NSISO8601DateFormatter *dateFormatter = [[NSISO8601DateFormatter alloc] init];
 		if (error == nil) {
 			ret["result"] = "ok";
-			GodotStringArray names;
-			GodotStringArray titles;
-			GodotStringArray unachieved_descriptions;
-			GodotStringArray achieved_descriptions;
-			GodotIntArray maximum_points;
-			Array hidden;
-			Array replayable;
-
-			for (NSUInteger i = 0; i < [descriptions count]; i++) {
-
-				GKAchievementDescription *description = [descriptions objectAtIndex:i];
-
-				const char *str = [description.identifier UTF8String];
-				names.push_back(String::utf8(str != NULL ? str : ""));
-
-				str = [description.title UTF8String];
-				titles.push_back(String::utf8(str != NULL ? str : ""));
-
-				str = [description.unachievedDescription UTF8String];
-				unachieved_descriptions.push_back(String::utf8(str != NULL ? str : ""));
-
-				str = [description.achievedDescription UTF8String];
-				achieved_descriptions.push_back(String::utf8(str != NULL ? str : ""));
-
-				maximum_points.push_back(description.maximumPoints);
-
-				hidden.push_back(description.hidden == YES);
-
-				replayable.push_back(description.replayable == YES);
+			Array result_achievements;
+			for (GKAchievement *achievement in achievements) {
+				Dictionary achievement_dict;
+				achievement_dict["identifier"] = String([achievement.identifier UTF8String] ?: "");
+				achievement_dict["percent_complete"] = achievement.percentComplete;
+				achievement_dict["completed"] = achievement.completed == YES;
+				NSString *isoDateString = [dateFormatter stringFromDate:achievement.lastReportedDate];
+				achievement_dict["last_reported_date"] = String([isoDateString UTF8String] ?: "");
+				result_achievements.push_back(achievement_dict);
 			}
-
-			ret["names"] = names;
-			ret["titles"] = titles;
-			ret["unachieved_descriptions"] = unachieved_descriptions;
-			ret["achieved_descriptions"] = achieved_descriptions;
-			ret["maximum_points"] = maximum_points;
-			ret["hidden"] = hidden;
-			ret["replayable"] = replayable;
-
+			ret["achievements"] = result_achievements;
 		} else {
 			ret["result"] = "error";
 			ret["error_code"] = (int64_t)error.code;
+			ret["error_description"] = [error.localizedDescription UTF8String];
 		};
 
 		pending_events.push_back(ret);
 	}];
 };
 
-void GameCenter::request_achievements() {
-	[GKAchievement loadAchievementsWithCompletionHandler:^(NSArray *achievements, NSError *error) {
+void GameCenter::load_achievement_descriptions() {
+	[GKAchievementDescription loadAchievementDescriptionsWithCompletionHandler:^(NSArray<GKAchievementDescription *> *descriptions, NSError *error) {
 		Dictionary ret;
-		ret["type"] = "achievements";
+		ret["type"] = "load_achievement_descriptions";
 		if (error == nil) {
 			ret["result"] = "ok";
-			GodotStringArray names;
-			GodotFloatArray percentages;
-
-			for (NSUInteger i = 0; i < [achievements count]; i++) {
-
-				GKAchievement *achievement = [achievements objectAtIndex:i];
-				const char *str = [achievement.identifier UTF8String];
-				names.push_back(String::utf8(str != NULL ? str : ""));
-
-				percentages.push_back(achievement.percentComplete);
+			Array result_descriptions;
+			for (GKAchievementDescription *description in descriptions) {
+				Dictionary description_dict;
+				description_dict["identifier"] = String([description.identifier UTF8String] ?: "");
+				description_dict["title"] = String([description.title UTF8String] ?: "");
+				description_dict["unachieved_description"] = String([description.unachievedDescription UTF8String] ?: "");
+				description_dict["achieved_description"] = String([description.achievedDescription UTF8String] ?: "");
+				description_dict["maximum_points"] = (int64_t)description.maximumPoints;
+				description_dict["hidden"] = description.hidden == YES;
+				description_dict["replayable"] = description.replayable == YES;
+				result_descriptions.push_back(description_dict);
 			}
-
-			ret["names"] = names;
-			ret["progress"] = percentages;
-
+			ret["descriptions"] = result_descriptions;
 		} else {
 			ret["result"] = "error";
 			ret["error_code"] = (int64_t)error.code;
+			ret["error_description"] = [error.localizedDescription UTF8String];
 		};
 
 		pending_events.push_back(ret);
@@ -292,11 +261,14 @@ void GameCenter::reset_achievements() {
 		} else {
 			ret["result"] = "error";
 			ret["error_code"] = (int64_t)error.code;
+			ret["error_description"] = [error.localizedDescription UTF8String];
 		};
 
 		pending_events.push_back(ret);
 	}];
 };
+
+// Native Game Center UI
 
 Error GameCenter::show_game_center(Dictionary p_params) {
 	ERR_FAIL_COND_V(!NSProtocolFromString(@"GKGameCenterControllerDelegate"), FAILED);


### PR DESCRIPTION
There were a few bugs and awkward APIs around the Achievements APIs, so I refactored them with the following goals:
* consistency with Apple's API naming
* consistency in results
* function params instead of options dict

Here are the changes to the API:

* changed `"name"` to `"identifier"`, Apple calls it "identifier" both in the API, and also in App Store Connect where all achievements are approved by Apple
* renamed "award_achievement" to "report_achievement" to follow [Apples API name](https://developer.apple.com/documentation/gamekit/gkachievement/report(_:withcompletionhandler:)?language=objc) when Apple gives feedback to devs they are likely to mention their own API names.
  * changed `award_achievement(Dictionary achievent_dictionary)` to `report_achievement(String identifier, double percent_complete, bool shows_completion_banner)`, "name" and "progress" were required with an error, now "identifier", and "percent_complete" are function parameters.  Also added documentation.
  * added "error_description" to error return in "report_achievement"
* renamed "request_achievements" to "load_achievements" following [Apple's API name](https://developer.apple.com/documentation/gamekit/gkachievement/loadachievements(completionhandler:)?language=objc)
  * changed return event from structure of arrays
  ```gd
  {
    "type": "achievements",
    "result": "ok",
    "names": ["a1", "a2"],
    "percentages": [100.0, 80.0],
  }
  ``` 
  * to array of structures
  ```gd
  {
    "type": "load_achievements",
    "result": "ok",
    "achievements": [
      {
        "identifier": "a1",
        "percent_complete": 100.0,
        "completed": true,
        "last_reported_date": "2026-03-04T08:24:07Z"
      },
      {
        "identifier": "a2",
        "percent_complete": 80.0,
        "completed": false,
        "last_reported_date": "2026-03-04T08:27:42Z"
      }
    ],
    ...
  }
  ```
  * added "last_reported_date" as an ISO 8601 date which can be parsed by Godot's [`Time. get_unix_time_from_datetime_string`](https://docs.godotengine.org/en/stable/classes/class_time.html#class-time-method-get-date-dict-from-system)
  * added "completed", renamed "name" to "identifier", and renamed "percentages" to "percent_complete" following [Apple's API](https://developer.apple.com/documentation/gamekit/gkachievement?language=objc)
  * added "error_description" to error return in "load_achievements"
* renamed "request_achievement_descriptions" to "load_achievement_descriptions" following [Apple's API name](https://developer.apple.com/documentation/gamekit/gkachievementdescription/loadachievementdescriptions(completionhandler:)?language=objc)
  * changed structure of arrays
  ```gd
  {
    "type": "achievement_descriptions",
    "result": "ok",
    "names": ["a1", "a2", ...],
    "titles": ["Achievement 1", "Achievement 2", ...],
    "unachieved_descriptions": ["Description 1", "Description 2", ...],
    "achieved_descriptions": ["Description 1", "Description 2", ...],
    "maximum_points": [50, 100, ...],
    "hidden": [true, false, ...],
    "replayable": [false, true, ...],
  }
  ```
  * to array of structures
  ```gd
  {
	"type": "load_achievement_descriptions",
	"result": "ok",
	"descriptions": [
		{
			"identifier": String,
			"title": String,
			"unachieved_description": String,
			"achieved_description": String,
			"maximum_points": int64,
			"hidden": bool,
			"replayable": bool,
		},
		...
	],
  }
  ```
  * added "error_description" to error return in "load_achievement_descriptions"
* "reset_achievements" is already the same name as [the Apple API](https://developer.apple.com/documentation/gamekit/gkachievement/resetachievements(completionhandler:)?language=objc)
  * added "error_description" to error return in "reset_achievements"
