### PR TITLE
gamecenter: migrate post_score to modern GKLeaderboard.submitScore API

### DIFF
--- a/plugins/gamecenter/game_center.mm
+++ b/plugins/gamecenter/game_center.mm
@@ -138,29 +138,42 @@ bool GameCenter::is_authenticated() {
 
 Error GameCenter::post_score(Dictionary p_score) {
 	ERR_FAIL_COND_V(!p_score.has("score") || !p_score.has("category"), ERR_INVALID_PARAMETER);
-	float score = p_score["score"];
+	int64_t score = p_score["score"];
 	String category = p_score["category"];
+	int64_t context = 0;
+	if (p_score.has("context")) {
+		context = p_score["context"];
+	}
 
 	NSString *cat_str = [[NSString alloc] initWithUTF8String:category.utf8().get_data()];
-	GKScore *reporter = [[GKScore alloc] initWithLeaderboardIdentifier:cat_str];
-	reporter.value = score;
 
-	ERR_FAIL_COND_V([GKScore respondsToSelector:@selector(reportScores)], ERR_UNAVAILABLE);
+	void (^completion_handler)(NSError *) = ^(NSError *error) {
+		Dictionary ret;
+		ret["type"] = "post_score";
+		if (error == nil) {
+			ret["result"] = "ok";
+		} else {
+			ret["result"] = "error";
+			ret["error_code"] = (int64_t)error.code;
+			ret["error_description"] = [error.localizedDescription UTF8String];
+		};
 
-	[GKScore reportScores:@[ reporter ]
-			withCompletionHandler:^(NSError *error) {
-				Dictionary ret;
-				ret["type"] = "post_score";
-				if (error == nil) {
-					ret["result"] = "ok";
-				} else {
-					ret["result"] = "error";
-					ret["error_code"] = (int64_t)error.code;
-					ret["error_description"] = [error.localizedDescription UTF8String];
-				};
+		pending_events.push_back(ret);
+	};
 
-				pending_events.push_back(ret);
-			}];
+	// Modern API (iOS 14+) — required for Game Center Challenges auto-matching.
+	// Legacy GKScore.reportScores: is deprecated and does not participate in challenges.
+	if (@available(iOS 14.0, *)) {
+		[GKLeaderboard submitScore:score
+						   context:context
+							player:[GKLocalPlayer local]
+					leaderboardIDs:@[ cat_str ]
+				 completionHandler:completion_handler];
+	} else {
+		GKScore *reporter = [[GKScore alloc] initWithLeaderboardIdentifier:cat_str];
+		reporter.value = score;
+		[GKScore reportScores:@[ reporter ] withCompletionHandler:completion_handler];
+	}
 
 	return OK;
 };


### PR DESCRIPTION
## Summary

Migrate `GameCenter::post_score` from the deprecated `GKScore.reportScores:` path to `GKLeaderboard.submitScore:context:player:leaderboardIDs:completionHandler:` on iOS 14+, with the legacy call retained as a fallback for older systems.

## Why

- `GKScore.reportScores:` has been deprecated since iOS 14 (2020).
- More importantly, the iOS 17/26 Game Center redesign and the Apple Games app (launched 2025) made **challenges auto-match on score submission**. Challenges only participate when scores are submitted via the modern `GKLeaderboard.submitScore(...)` API. Games still using `GKScore.reportScores:` will have their leaderboards work but will silently miss out on challenge auto-matching — which Apple is actively promoting as a featuring signal.

WWDC25 references:
- [Get started with Game Center (WWDC25 214)](https://developer.apple.com/videos/play/wwdc2025/214/)
- [Engage players with the Apple Games app (WWDC25 215)](https://developer.apple.com/videos/play/wwdc2025/215/)

## Changes

- `score` is now `int64_t` instead of `float` (matches `GKLeaderboard` API, which takes `NSInteger`).
- Optional `"context"` field in the params dict flows through to GameKit as challenge/submission metadata.
- Removes a dead `ERR_FAIL_COND_V` that checked for a selector with the wrong signature (`respondsToSelector:@selector(reportScores)` — the real selector is `reportScores:withCompletionHandler:`).
- Runtime `@available(iOS 14.0, *)` guard — modern API on new iOS, legacy fallback below.

## Public API

Unchanged. Existing callers of `_gc.post_score({"score": N, "category": "lb_id"})` continue to work exactly as before. The `"context"` key is purely additive.

## Testing

Built against Godot 4.6-stable headers on macOS 15 / Xcode 26.3 (iOS 26.2 SDK). Verified on a physical device:
- Game Center authentication works.
- Score submission lands on the leaderboard.
- `nm -u` on the resulting `.a` confirms both `submitScore:context:player:leaderboardIDs:completionHandler:` and `reportScores:withCompletionHandler:` symbols are present (both code paths survive).