### PR TITLE
Fix photo_picker not presenting picker UI on Godot 4.6.

### DIFF
--- a/plugins/photo_picker/photo_picker.mm
+++ b/plugins/photo_picker/photo_picker.mm
@@ -35,6 +35,7 @@
 
 #if VERSION_MAJOR == 4
 #if VERSION_MINOR >= 6
+#import "drivers/apple_embedded/app_delegate_service.h"
 #import "drivers/apple_embedded/godot_app_delegate.h"
 #import "drivers/apple_embedded/godot_view_controller.h"
 #elif VERSION_MINOR >= 5
@@ -63,7 +64,13 @@ PhotoPicker *instance = NULL;
 	dispatch_async(dispatch_get_main_queue(), ^{
 		_strongify(self);
 
+#if VERSION_MAJOR == 4 && VERSION_MINOR >= 6
+		// Godot 4.6 hosts the engine view controller inside a SwiftUI WindowGroup,
+		// so the app delegate no longer exposes a window/rootViewController.
+		UIViewController *root_controller = [GDTAppDelegateService viewController];
+#else
 		UIViewController *root_controller = [[UIApplication sharedApplication] delegate].window.rootViewController;
+#endif
 
 		if (!root_controller) {
 			return;


### PR DESCRIPTION
Godot 4.6 hosts the engine view controller inside a SwiftUI WindowGroup, so [UIApplication.sharedApplication.delegate window].rootViewController is nil and the picker silently fails after the permission dialog. Use GDTAppDelegateService.viewController instead on 4.6+.

Tested with Godot 4.6.2, iOS 26.4.2 on iPhone 17 Pro.

Note: Claude Code was used to find and fix the bug.